### PR TITLE
cleanups for folly::F14

### DIFF
--- a/BUILD.folly
+++ b/BUILD.folly
@@ -1,11 +1,21 @@
 cc_library(
     name = "folly",
     includes = [""],
-    srcs = ["folly/container/detail/F14Table.cpp"],
+    srcs = [
+        "folly/FileUtil.cpp",
+        "folly/container/detail/F14Table.cpp",
+        "folly/lang/Assume.cpp",
+        "folly/lang/SafeAssert.cpp",
+    ],
     hdrs = glob([
         "folly/**/*.h",
     ]),
-    defines = ["FOLLY_NO_CONFIG"],
+    defines = [
+        "FOLLY_NO_CONFIG",
+        "FOLLY_HAVE_MEMRCHR",
+    ],
     visibility = ["//visibility:public"],
-    deps = [],
+    deps = [
+        "@com_github_google_glog//:glog",
+    ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,6 +36,17 @@ new_http_archive(
     urls = ["https://github.com/google/sparsehash/archive/master.zip"],
 )
 
+http_archive(
+    name = "com_github_gflags_gflags",
+    strip_prefix = "gflags-master",
+    urls = ["https://github.com/gflags/gflags/archive/master.zip"],
+)
+http_archive(
+    name = "com_github_google_glog",
+    strip_prefix = "glog-master",
+    urls = ["https://github.com/google/glog/archive/master.zip"],
+)
+
 # Facebook folly
 new_http_archive(
     name = "facebook_folly",

--- a/hashtable_benchmarks.cc
+++ b/hashtable_benchmarks.cc
@@ -899,6 +899,8 @@ void ConfigureBenchmark(benchmark::internal::Benchmark* b) {
   (__gnu_cxx::hash_set)    \
   (std::unordered_set)     \
   (folly::F14ValueSet)     \
+  (folly::F14NodeSet)      \
+  (folly::F14VectorSet)    \
   (google::dense_hash_set)
 // clang-format on
 

--- a/hashtable_benchmarks.cc
+++ b/hashtable_benchmarks.cc
@@ -74,11 +74,15 @@ class alignas(kSize < 8 ? 4 : 8) Value : private Ballast<kSize - 4> {
   uint32_t value_;
 };
 
-// Use a zero cost hash function. The purpose of this benchmark is to focus on
+// Use a ~zero cost hash function. The purpose of this benchmark is to focus on
 // the implementations of the containers, not the quality or speed of their hash
-// functions.
+// functions.  Bit mixing is disabled for folly::F14*.
 struct Hash {
-  size_t operator()(size_t x) const { return x; }
+  using folly_is_avalanching = std::true_type;
+
+  size_t operator()(uint32_t x) const {
+    return (size_t{x} << 32) | x;
+  }
 };
 
 struct Eq {

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,1 +1,1 @@
-build --copt=--std=c++14 -c opt
+build --copt=--std=c++14 -c opt --copt=-march=corei7 --copt=-mtune=core-avx2


### PR DESCRIPTION
Let me know of you want me to be more platform independent, or if mirroring bits 31:0 onto 63:32 should be done only for F14 (which needs it if the bit mixer is bypassed).