### PR TITLE
benchmark rerun after folly D9149727, which works around bad codegen by gcc 5.5

### DIFF
--- a/results/ngbronson-2018-08-03.json
+++ b/results/ngbronson-2018-08-03.json
@@ -1,0 +1,13358 @@
+{
+  "context": {
+    "date": "2018-08-03 07:44:48",
+    "executable": "./bazel-bin/hashtable_benchmarks@a700b6860de1519a38c08d5789a66a2078a74f69-dirty",
+    "num_cpus": 56,
+    "mhz_per_cpu": 2401,
+    "cpu_scaling_enabled": false,
+    "caches": [
+      {
+        "type": "Data",
+        "level": 1,
+        "size": 32000000,
+        "num_sharing": 2
+      },
+      {
+        "type": "Instruction",
+        "level": 1,
+        "size": 32000000,
+        "num_sharing": 2
+      },
+      {
+        "type": "Unified",
+        "level": 2,
+        "size": 256000000,
+        "num_sharing": 2
+      },
+      {
+        "type": "Unified",
+        "level": 3,
+        "size": 35840000000,
+        "num_sharing": 28
+      }
+    ],
+    "library_build_type": "release"
+  },
+  "benchmarks": [
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33572864,
+      "real_time": 9.6546955402575314e+00,
+      "cpu_time": 9.6547669272421910e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.249 size=194 num_sets=338"
+    },
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33745920,
+      "real_time": 9.5317424804157636e+00,
+      "cpu_time": 9.5310098820835254e+00,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=1.255 size=390 num_sets=169"
+    },
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34648064,
+      "real_time": 9.6197948097576695e+00,
+      "cpu_time": 9.6197188679863928e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.246 size=6152 num_sets=11"
+    },
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.0199208588801412e+01,
+      "cpu_time": 1.0199157714843752e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.251 size=98318 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 9.9865644642704865e+00,
+      "cpu_time": 9.9866250157356333e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.247 size=1572870 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33619968,
+      "real_time": 1.0022213210516970e+01,
+      "cpu_time": 1.0022301627413791e+01,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=1.497 size=192 num_sets=342"
+    },
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33572864,
+      "real_time": 9.8796079820058917e+00,
+      "cpu_time": 9.8796643026939872e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.497 size=388 num_sets=169"
+    },
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34636800,
+      "real_time": 9.7840013917251945e+00,
+      "cpu_time": 9.7840653293606774e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.500 size=6150 num_sets=11"
+    },
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.0319126886315644e+01,
+      "cpu_time": 1.0319081038236606e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.502 size=98316 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.0360608371229318e+01,
+      "cpu_time": 1.0360700875520697e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.503 size=1572868 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33572864,
+      "real_time": 9.5049101460054910e+00,
+      "cpu_time": 9.5049617452952564e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.247 size=194 num_sets=338"
+    },
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33745920,
+      "real_time": 9.8460338226382600e+00,
+      "cpu_time": 9.8459973827947298e+00,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=1.252 size=390 num_sets=169"
+    },
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34648064,
+      "real_time": 1.0505192578966305e+01,
+      "cpu_time": 1.0505021434963879e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.253 size=6152 num_sets=11"
+    },
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.0447898546317447e+01,
+      "cpu_time": 1.0447830945253360e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.250 size=98318 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 9.9320516255829716e+00,
+      "cpu_time": 9.9321077764034253e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.250 size=1572870 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33619968,
+      "real_time": 1.0280325324828310e+01,
+      "cpu_time": 1.0280305382801128e+01,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=1.493 size=192 num_sets=342"
+    },
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33572864,
+      "real_time": 9.8964101934035931e+00,
+      "cpu_time": 9.8963808985733301e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.497 size=388 num_sets=169"
+    },
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34636800,
+      "real_time": 9.9085287878624353e+00,
+      "cpu_time": 9.9085977630728230e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.500 size=6150 num_sets=11"
+    },
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.0597368316211941e+01,
+      "cpu_time": 1.0597159683704369e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.499 size=98316 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.0792064131237566e+01,
+      "cpu_time": 1.0792126208543788e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.499 size=1572868 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33562624,
+      "real_time": 1.2504744548273285e+01,
+      "cpu_time": 1.2504385413965256e+01,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=1.000 size=17 num_sets=3856"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33685504,
+      "real_time": 1.2009739520205802e+01,
+      "cpu_time": 1.2009699929085192e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.000 size=257 num_sets=256"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 35627008,
+      "real_time": 1.1918731277928897e+01,
+      "cpu_time": 1.1918670745519798e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.000 size=4349 num_sets=16"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.1687909307056543e+01,
+      "cpu_time": 1.1688005268573749e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=67307 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.2225598311488284e+01,
+      "cpu_time": 1.2224897265434254e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=1056323 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33564160,
+      "real_time": 1.4464922056673830e+01,
+      "cpu_time": 1.4464884448173292e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.000 size=35 num_sets=1873"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33668096,
+      "real_time": 1.4488511561346719e+01,
+      "cpu_time": 1.4488005588436028e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=539 num_sets=122"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 35610624,
+      "real_time": 1.4568211230973636e+01,
+      "cpu_time": 1.4568337218690731e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=4347 num_sets=16"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.4819164562140941e+01,
+      "cpu_time": 1.4819162100553505e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=67305 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.5987168922038109e+01,
+      "cpu_time": 1.5986471444368396e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=1056321 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33562624,
+      "real_time": 1.1916921051455063e+01,
+      "cpu_time": 1.1916896813550611e+01,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=1.000 size=17 num_sets=3856"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33685504,
+      "real_time": 1.1899715433520507e+01,
+      "cpu_time": 1.1899800489848651e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.000 size=257 num_sets=256"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 35627008,
+      "real_time": 1.2497696072586132e+01,
+      "cpu_time": 1.2497654223447480e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.000 size=4349 num_sets=16"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.1810790567778895e+01,
+      "cpu_time": 1.1810761809349092e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=67307 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.2325656939538021e+01,
+      "cpu_time": 1.2325429886579533e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=1056323 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33564160,
+      "real_time": 1.4357568856535291e+01,
+      "cpu_time": 1.4357678905117819e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.000 size=35 num_sets=1873"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33668096,
+      "real_time": 1.4380285924102214e+01,
+      "cpu_time": 1.4380289785320839e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=539 num_sets=122"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 35610624,
+      "real_time": 1.4576386012889364e+01,
+      "cpu_time": 1.4576410736301630e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=4347 num_sets=16"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.4851430307771807e+01,
+      "cpu_time": 1.4850587487220725e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=67305 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, std::unordered_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.5548465626125108e+01,
+      "cpu_time": 1.5548430562019304e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=1056321 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556992,
+      "real_time": 3.2513518197821556e+00,
+      "cpu_time": 3.2512367616262705e+00,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=1.038 size=21 num_sets=3121"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33692160,
+      "real_time": 3.2501112779814840e+00,
+      "cpu_time": 3.2501431787097546e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=321 num_sets=205"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34085376,
+      "real_time": 3.2679737442405332e+00,
+      "cpu_time": 3.2680047595778632e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=5121 num_sets=13"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 3.2068072641777690e+00,
+      "cpu_time": 3.2068248689175327e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.038 size=81921 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 3.4479086252758862e+00,
+      "cpu_time": 3.4479082822799527e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.038 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33561600,
+      "real_time": 3.5003094751356576e+00,
+      "cpu_time": 3.5003280832856816e+00,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.072 size=19 num_sets=3450"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33645568,
+      "real_time": 3.5636545136445306e+00,
+      "cpu_time": 3.5636743002823197e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.089 size=319 num_sets=206"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34072064,
+      "real_time": 3.5658877089406689e+00,
+      "cpu_time": 3.5657821316607312e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.092 size=5119 num_sets=13"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 3.5881626558875723e+00,
+      "cpu_time": 3.5881773531436520e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.093 size=81919 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 3.5774263551502372e+00,
+      "cpu_time": 3.5773959457873636e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=1310719 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33561600,
+      "real_time": 3.6315471047576739e+00,
+      "cpu_time": 3.6313796422101161e+00,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=1.046 size=25 num_sets=2622"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33707520,
+      "real_time": 3.4356515948245692e+00,
+      "cpu_time": 3.4356818597156491e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=385 num_sets=171"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34608640,
+      "real_time": 3.5647974955858373e+00,
+      "cpu_time": 3.5648230037354813e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=6145 num_sets=11"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 3.5999789815832628e+00,
+      "cpu_time": 3.6000038981437261e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.046 size=98305 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 3.8349838860085583e+00,
+      "cpu_time": 3.8349990248680177e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33561600,
+      "real_time": 3.6389280670385702e+00,
+      "cpu_time": 3.6389577374141848e+00,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=1.089 size=23 num_sets=2850"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33728512,
+      "real_time": 3.7558414564518352e+00,
+      "cpu_time": 3.7558580704656759e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.107 size=383 num_sets=172"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34597376,
+      "real_time": 3.7726055042194644e+00,
+      "cpu_time": 3.7726329592163008e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.108 size=6143 num_sets=11"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 3.6368845712786424e+00,
+      "cpu_time": 3.6367239952087309e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.110 size=98303 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14ValueSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.0221905805992719e+00,
+      "cpu_time": 4.0221994817256776e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.109 size=1572863 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33561600,
+      "real_time": 3.6401925629827470e+00,
+      "cpu_time": 3.6401109005529411e+00,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=1.046 size=25 num_sets=2622"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33707520,
+      "real_time": 3.6551245815925775e+00,
+      "cpu_time": 3.6551447570157265e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=385 num_sets=171"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34608640,
+      "real_time": 3.6848794824052944e+00,
+      "cpu_time": 3.6849044920574916e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.048 size=6145 num_sets=11"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 3.6499372413345554e+00,
+      "cpu_time": 3.6499526202678219e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.046 size=98305 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.2699710434135341e+00,
+      "cpu_time": 4.2699784040451423e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.044 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33561600,
+      "real_time": 3.6713005839914516e+00,
+      "cpu_time": 3.6713244303012624e+00,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=1.087 size=23 num_sets=2850"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33728512,
+      "real_time": 3.8153886463886924e+00,
+      "cpu_time": 3.8154160195386244e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.106 size=383 num_sets=172"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34597376,
+      "real_time": 3.9602606699613587e+00,
+      "cpu_time": 3.9602854563305367e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.110 size=6143 num_sets=11"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.0445939930577879e+00,
+      "cpu_time": 4.0446196794511335e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.107 size=98303 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.3285552919769543e+00,
+      "cpu_time": 4.3285780847071225e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.109 size=1572863 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33561600,
+      "real_time": 3.6444051814934029e+00,
+      "cpu_time": 3.6442870125381903e+00,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=1.047 size=25 num_sets=2622"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33707520,
+      "real_time": 3.6436094820902305e+00,
+      "cpu_time": 3.6436280094173594e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=385 num_sets=171"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34608640,
+      "real_time": 3.6739466550814188e+00,
+      "cpu_time": 3.6739753714678476e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=6145 num_sets=11"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 3.8495642229463556e+00,
+      "cpu_time": 3.8495955169199463e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=98305 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.1371208681084681e+00,
+      "cpu_time": 4.1367043256759537e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.046 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33561600,
+      "real_time": 4.0041826932508471e+00,
+      "cpu_time": 4.0042183030605063e+00,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=1.087 size=23 num_sets=2850"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33728512,
+      "real_time": 4.1812885980389218e+00,
+      "cpu_time": 4.1813162406928761e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.107 size=383 num_sets=172"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34597376,
+      "real_time": 4.1994898234529634e+00,
+      "cpu_time": 4.1994117993225695e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.110 size=6143 num_sets=11"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.3044181552431837e+00,
+      "cpu_time": 4.3044449090958246e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.114 size=98303 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14NodeSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.5418246941153484e+00,
+      "cpu_time": 4.5418473780153352e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.109 size=1572863 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556992,
+      "real_time": 3.9272111386273973e+00,
+      "cpu_time": 3.9272163011511223e+00,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=1.038 size=21 num_sets=3121"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33692160,
+      "real_time": 3.9406882761894466e+00,
+      "cpu_time": 3.9407113702417611e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=321 num_sets=205"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34085376,
+      "real_time": 3.9844106984486234e+00,
+      "cpu_time": 3.9844297742233188e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=5121 num_sets=13"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.1348471313540358e+00,
+      "cpu_time": 4.1348658204077804e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=81921 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.3977834707220609e+00,
+      "cpu_time": 4.3978118300437030e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33561600,
+      "real_time": 4.3782319597939692e+00,
+      "cpu_time": 4.3782773467295559e+00,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.072 size=19 num_sets=3450"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33645568,
+      "real_time": 4.5162427169420329e+00,
+      "cpu_time": 4.5162899018380918e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.089 size=319 num_sets=206"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34072064,
+      "real_time": 4.3944103080224943e+00,
+      "cpu_time": 4.3944521822922358e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.090 size=5119 num_sets=13"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.3571475316639408e+00,
+      "cpu_time": 4.3571781218052443e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=81919 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.3968171326014271e+00,
+      "cpu_time": 4.3968266248704335e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.089 size=1310719 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556992,
+      "real_time": 4.1519102410578546e+00,
+      "cpu_time": 4.1519412407404745e+00,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=1.039 size=21 num_sets=3121"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33692160,
+      "real_time": 4.1014424356571144e+00,
+      "cpu_time": 4.1014725384184860e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=321 num_sets=205"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34085376,
+      "real_time": 4.1825928631894369e+00,
+      "cpu_time": 4.1826184930451769e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.038 size=5121 num_sets=13"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.2030379177049326e+00,
+      "cpu_time": 4.2030705213547250e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=81921 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.4364014684106223e+00,
+      "cpu_time": 4.4364237785340279e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.038 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33561600,
+      "real_time": 4.2380718194647296e+00,
+      "cpu_time": 4.2380922542428463e+00,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.072 size=19 num_sets=3450"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33645568,
+      "real_time": 4.5298481841427947e+00,
+      "cpu_time": 4.5298784374809440e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.090 size=319 num_sets=206"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34072064,
+      "real_time": 4.5410424969345966e+00,
+      "cpu_time": 4.5410716239556335e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=5119 num_sets=13"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.4529357978717599e+00,
+      "cpu_time": 4.4529730975628450e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=81919 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, folly::F14VectorSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.6258037400548346e+00,
+      "cpu_time": 4.6258010864257599e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=1310719 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33562624,
+      "real_time": 3.1424464904770257e+00,
+      "cpu_time": 3.1424730676601076e+00,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=2.320 size=17 num_sets=3856"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33685504,
+      "real_time": 3.2211117335895967e+00,
+      "cpu_time": 3.2211407019470126e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.328 size=257 num_sets=256"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33562624,
+      "real_time": 3.1549134717930052e+00,
+      "cpu_time": 3.1549397925501266e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.331 size=4097 num_sets=16"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 3.5738665360440791e+00,
+      "cpu_time": 3.5738895833491529e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.323 size=65537 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 3.4956570971189649e+00,
+      "cpu_time": 3.4954257905484218e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.325 size=1048577 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33569280,
+      "real_time": 3.3342456127625804e+00,
+      "cpu_time": 3.3342649589148228e+00,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=2.752 size=31 num_sets=2115"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33750528,
+      "real_time": 3.3277697411010863e+00,
+      "cpu_time": 3.3277966495813254e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.870 size=511 num_sets=129"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 37744128,
+      "real_time": 3.3791537317613050e+00,
+      "cpu_time": 3.3791778154208023e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.876 size=8191 num_sets=9"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.0120369249052601e+00,
+      "cpu_time": 4.0120731890202164e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.875 size=131071 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.2410235323586676e+00,
+      "cpu_time": 4.2401664257048992e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.861 size=2097151 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33562624,
+      "real_time": 3.7892448470589297e+00,
+      "cpu_time": 3.7892828343816523e+00,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=2.324 size=17 num_sets=3856"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33685504,
+      "real_time": 3.6026606859878458e+00,
+      "cpu_time": 3.6026924816085093e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.336 size=257 num_sets=256"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33562624,
+      "real_time": 3.6470786378984195e+00,
+      "cpu_time": 3.6471044099532324e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.330 size=4097 num_sets=16"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 3.7678091757697985e+00,
+      "cpu_time": 3.7678243815898593e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.314 size=65537 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.1008121343111270e+00,
+      "cpu_time": 4.1008269786833829e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.320 size=1048577 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33569280,
+      "real_time": 3.9835577742745980e+00,
+      "cpu_time": 3.9835846047339976e+00,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=2.746 size=31 num_sets=2115"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33750528,
+      "real_time": 4.0703949097097327e+00,
+      "cpu_time": 4.0704240241811771e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.858 size=511 num_sets=129"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 37744128,
+      "real_time": 3.9885264089080055e+00,
+      "cpu_time": 3.9885612670664830e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.869 size=8191 num_sets=9"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.1946535134229634e+00,
+      "cpu_time": 4.1939293444156647e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.878 size=131071 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Hot, google::dense_hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.5207144694359158e+00,
+      "cpu_time": 4.5207468569279827e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.867 size=2097151 num_sets=1"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 67108868,
+      "real_time": 7.1632324243641051e+01,
+      "cpu_time": 7.1629781998408930e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.248 size=194 num_sets=345922"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 67109250,
+      "real_time": 7.2201782704499223e+01,
+      "cpu_time": 7.2199650405867942e+01,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=1.253 size=390 num_sets=172075"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 67112168,
+      "real_time": 7.2461531280220740e+01,
+      "cpu_time": 7.2460191809032281e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.250 size=6152 num_sets=10909"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 67151194,
+      "real_time": 7.3612176032708305e+01,
+      "cpu_time": 7.3612250424020630e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.250 size=98318 num_sets=683"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67633410,
+      "real_time": 7.3818834721853179e+01,
+      "cpu_time": 7.3819123034015576e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.249 size=1572870 num_sets=43"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 67108992,
+      "real_time": 7.7769166210816863e+01,
+      "cpu_time": 7.7767801042221194e+01,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=1.495 size=192 num_sets=349526"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 67108868,
+      "real_time": 1.1876799990561300e+02,
+      "cpu_time": 1.1876807087552125e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.497 size=388 num_sets=172961"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 67114950,
+      "real_time": 9.0150265123793460e+01,
+      "cpu_time": 9.0149344028417303e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.500 size=6150 num_sets=10913"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 67149828,
+      "real_time": 8.1147450049481932e+01,
+      "cpu_time": 8.1147056251581091e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.500 size=98316 num_sets=683"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 67633324,
+      "real_time": 8.3333759470911176e+01,
+      "cpu_time": 8.3331350075297593e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.499 size=1572868 num_sets=43"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20972370,
+      "real_time": 7.5709705048542276e+01,
+      "cpu_time": 7.5707092522209422e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.248 size=194 num_sets=21621"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20972250,
+      "real_time": 7.7434025448097245e+01,
+      "cpu_time": 7.7433116666070958e+01,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=1.253 size=390 num_sets=10755"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20978320,
+      "real_time": 8.2048380547974645e+01,
+      "cpu_time": 8.2046145258532690e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.250 size=6152 num_sets=682"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21138370,
+      "real_time": 8.0843315814187818e+01,
+      "cpu_time": 8.0842418880924910e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.250 size=98318 num_sets=43"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 23593050,
+      "real_time": 8.3623221884719456e+01,
+      "cpu_time": 8.3616523933955420e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.249 size=1572870 num_sets=3"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20972160,
+      "real_time": 8.8362035114279365e+01,
+      "cpu_time": 8.8361588029082085e+01,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=1.495 size=192 num_sets=21846"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20973340,
+      "real_time": 9.8054482441961881e+01,
+      "cpu_time": 9.8051117656986548e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.498 size=388 num_sets=10811"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 21002250,
+      "real_time": 9.4194027056409837e+01,
+      "cpu_time": 9.4190607387302094e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.500 size=6150 num_sets=683"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21137940,
+      "real_time": 9.4882697704609058e+01,
+      "cpu_time": 9.4879097584723567e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.500 size=98316 num_sets=43"
+    },
+    {
+      "name": "BM<FindHit_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 23593020,
+      "real_time": 9.9763776371558905e+01,
+      "cpu_time": 9.9761738047946281e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.499 size=1572868 num_sets=3"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 67108877,
+      "real_time": 7.7072321138723211e+01,
+      "cpu_time": 7.7071579710684020e+01,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=1.000 size=17 num_sets=3947581"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 67108868,
+      "real_time": 1.9398134918991519e+02,
+      "cpu_time": 1.9398200923311714e+02,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.000 size=257 num_sets=261124"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 67109419,
+      "real_time": 1.2104197549619292e+02,
+      "cpu_time": 1.2104189356787631e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.000 size=4349 num_sets=15431"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 67172386,
+      "real_time": 1.2390702288268280e+02,
+      "cpu_time": 1.2390708929112564e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=67307 num_sets=998"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67604672,
+      "real_time": 1.7888644242126816e+02,
+      "cpu_time": 1.7888115333212519e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=1056323 num_sets=64"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 67108895,
+      "real_time": 9.9508927538879718e+01,
+      "cpu_time": 9.9505796064739670e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.000 size=35 num_sets=1917397"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 67109273,
+      "real_time": 1.3688827554938126e+02,
+      "cpu_time": 1.3688572489825626e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=539 num_sets=124507"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 67108986,
+      "real_time": 1.3105321251104968e+02,
+      "cpu_time": 1.3104955252937359e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=4347 num_sets=15438"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 67170390,
+      "real_time": 1.3553119866774165e+02,
+      "cpu_time": 1.3552819379193721e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=67305 num_sets=998"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 67604544,
+      "real_time": 1.3563182581189926e+02,
+      "cpu_time": 1.3562762611045773e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=1056321 num_sets=64"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971540,
+      "real_time": 1.1153543532292986e+02,
+      "cpu_time": 1.1153281237334248e+02,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=1.000 size=17 num_sets=246724"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20972485,
+      "real_time": 1.2104164947592206e+02,
+      "cpu_time": 1.2103500009655387e+02,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.000 size=257 num_sets=16321"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20983925,
+      "real_time": 1.2664104159973446e+02,
+      "cpu_time": 1.2663726423916883e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.000 size=4349 num_sets=965"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21201705,
+      "real_time": 1.2508178099281992e+02,
+      "cpu_time": 1.2507873088508724e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=67307 num_sets=63"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 21126460,
+      "real_time": 1.7900375318368461e+02,
+      "cpu_time": 1.7900100864034738e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=1056323 num_sets=4"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971650,
+      "real_time": 1.3250896413667101e+02,
+      "cpu_time": 1.3250146554992367e+02,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.000 size=35 num_sets=119838"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20972490,
+      "real_time": 1.4721930531271124e+02,
+      "cpu_time": 1.4721363676893128e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=539 num_sets=7782"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20974275,
+      "real_time": 1.5293046364449097e+02,
+      "cpu_time": 1.5292868859591047e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=4347 num_sets=965"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21201075,
+      "real_time": 1.4996207929399543e+02,
+      "cpu_time": 1.4995725457317619e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=67305 num_sets=63"
+    },
+    {
+      "name": "BM<FindHit_Cold, std::unordered_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 21126420,
+      "real_time": 1.5886132771828039e+02,
+      "cpu_time": 1.5885501367482300e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=1056321 num_sets=4"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 67108881,
+      "real_time": 2.1912397008267259e+01,
+      "cpu_time": 2.1911958210120908e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=1.039 size=21 num_sets=3195661"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 67108902,
+      "real_time": 3.1600588682273422e+01,
+      "cpu_time": 3.1600050094695131e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=321 num_sets=209062"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 67110705,
+      "real_time": 3.2929139346346282e+01,
+      "cpu_time": 3.2929089271228719e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=5121 num_sets=13105"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 67175220,
+      "real_time": 3.5287647788332443e+01,
+      "cpu_time": 3.5285080525228352e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=81921 num_sets=820"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 68157492,
+      "real_time": 3.5287975723867646e+01,
+      "cpu_time": 3.5286173543474732e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.038 size=1310721 num_sets=52"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 67108874,
+      "real_time": 1.5397185230608713e+01,
+      "cpu_time": 1.5396455243757666e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.071 size=19 num_sets=3532046"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 67108987,
+      "real_time": 5.7512474176311699e+01,
+      "cpu_time": 5.7512388497236202e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.089 size=319 num_sets=210373"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 67110090,
+      "real_time": 4.0193190350753099e+01,
+      "cpu_time": 4.0192735742121648e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=5119 num_sets=13110"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 67173580,
+      "real_time": 4.4840900591659604e+01,
+      "cpu_time": 4.4840227809802890e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=81919 num_sets=820"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 68157388,
+      "real_time": 4.4646415369009539e+01,
+      "cpu_time": 4.4645909714146129e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.090 size=1310719 num_sets=52"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971625,
+      "real_time": 4.5946259947173786e+01,
+      "cpu_time": 4.5946189815999546e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=1.047 size=25 num_sets=167773"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20972875,
+      "real_time": 4.6691271112911885e+01,
+      "cpu_time": 4.6688624044153222e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=385 num_sets=10895"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20985175,
+      "real_time": 4.8247122002898372e+01,
+      "cpu_time": 4.8247219096336501e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=6145 num_sets=683"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21135575,
+      "real_time": 4.7109767048883874e+01,
+      "cpu_time": 4.7108510698191580e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=98305 num_sets=43"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 23592975,
+      "real_time": 4.7051425400142698e+01,
+      "cpu_time": 4.7051520844654398e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.046 size=1572865 num_sets=3"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971630,
+      "real_time": 4.4972026115619968e+01,
+      "cpu_time": 4.4970681010491788e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=1.088 size=23 num_sets=182362"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20973080,
+      "real_time": 4.5986167916110674e+01,
+      "cpu_time": 4.5986203218598511e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.107 size=383 num_sets=10952"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20978345,
+      "real_time": 4.9064345579611285e+01,
+      "cpu_time": 4.9064427103281815e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.110 size=6143 num_sets=683"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21135145,
+      "real_time": 4.9704219040897883e+01,
+      "cpu_time": 4.9704067608718304e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.110 size=98303 num_sets=43"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14ValueSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 23592945,
+      "real_time": 5.1854408536881010e+01,
+      "cpu_time": 5.1853792055211379e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.109 size=1572863 num_sets=3"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 67108875,
+      "real_time": 6.2487594181662487e+01,
+      "cpu_time": 6.2485927248817219e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=1.047 size=25 num_sets=2684355"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 67108965,
+      "real_time": 8.6123284560987202e+01,
+      "cpu_time": 8.6121149074494326e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=385 num_sets=174309"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 67109545,
+      "real_time": 9.0951783748877475e+01,
+      "cpu_time": 9.0951186422141035e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=6145 num_sets=10921"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 67142315,
+      "real_time": 6.4247710479299187e+01,
+      "cpu_time": 6.4247252585794712e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=98305 num_sets=683"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67633195,
+      "real_time": 5.9246414252313386e+01,
+      "cpu_time": 5.9246208566668223e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.046 size=1572865 num_sets=43"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 67108871,
+      "real_time": 6.0662394996826372e+01,
+      "cpu_time": 6.0660339867733171e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=1.088 size=23 num_sets=2917777"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 67108877,
+      "real_time": 6.9885385263407457e+01,
+      "cpu_time": 6.9883940987422633e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.107 size=383 num_sets=175219"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 67112275,
+      "real_time": 6.9967924733757798e+01,
+      "cpu_time": 6.9967198519196344e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.109 size=6143 num_sets=10925"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 67140949,
+      "real_time": 7.5781648483393838e+01,
+      "cpu_time": 7.5780416493666237e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.109 size=98303 num_sets=683"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 67633109,
+      "real_time": 7.9739818891316602e+01,
+      "cpu_time": 7.9738453676584371e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.109 size=1572863 num_sets=43"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971625,
+      "real_time": 6.1453237502476142e+01,
+      "cpu_time": 6.1450694688657023e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=1.047 size=25 num_sets=167773"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20972875,
+      "real_time": 6.1329074578444285e+01,
+      "cpu_time": 6.1327720162347255e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=385 num_sets=10895"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20985175,
+      "real_time": 5.4686414988079008e+01,
+      "cpu_time": 5.4685137436314399e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=6145 num_sets=683"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21135575,
+      "real_time": 5.4744526557250452e+01,
+      "cpu_time": 5.4743358153265987e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=98305 num_sets=43"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 23592975,
+      "real_time": 5.5388495287814997e+01,
+      "cpu_time": 5.5385783310498972e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.046 size=1572865 num_sets=3"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971630,
+      "real_time": 5.1576184934198579e+01,
+      "cpu_time": 5.1575632175463703e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=1.088 size=23 num_sets=182362"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20973080,
+      "real_time": 5.3399157914207620e+01,
+      "cpu_time": 5.3398122927105057e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.108 size=383 num_sets=10952"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20978345,
+      "real_time": 6.0828957687883445e+01,
+      "cpu_time": 6.0825068755421711e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.109 size=6143 num_sets=683"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21135145,
+      "real_time": 6.3028144564742142e+01,
+      "cpu_time": 6.3024990649453443e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.109 size=98303 num_sets=43"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14NodeSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 23592945,
+      "real_time": 6.1231395823358035e+01,
+      "cpu_time": 6.1223587559762954e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.109 size=1572863 num_sets=3"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 67108881,
+      "real_time": 3.4674238689607272e+01,
+      "cpu_time": 3.4673500456667171e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=1.039 size=21 num_sets=3195661"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 67108902,
+      "real_time": 8.1401001587335145e+01,
+      "cpu_time": 8.1400276255452297e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=321 num_sets=209062"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 67110705,
+      "real_time": 6.1913577983854729e+01,
+      "cpu_time": 6.1913694812178633e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=5121 num_sets=13105"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 67175220,
+      "real_time": 6.7463874986972399e+01,
+      "cpu_time": 6.7463357023617206e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=81921 num_sets=820"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 68157492,
+      "real_time": 6.7938411828763734e+01,
+      "cpu_time": 6.7938186633979385e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=1310721 num_sets=52"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 67108874,
+      "real_time": 3.1951826641727823e+01,
+      "cpu_time": 3.1951596863329591e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.071 size=19 num_sets=3532046"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 67108987,
+      "real_time": 6.6057704802596561e+01,
+      "cpu_time": 6.6056844726325380e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.089 size=319 num_sets=210373"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 67110090,
+      "real_time": 7.1664986773739940e+01,
+      "cpu_time": 7.1664780974070482e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=5119 num_sets=13110"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 67173580,
+      "real_time": 8.0311069714390911e+01,
+      "cpu_time": 8.0310821724850939e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=81919 num_sets=820"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 68157388,
+      "real_time": 8.2413176693317155e+01,
+      "cpu_time": 8.2413302443454498e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.090 size=1310719 num_sets=52"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971545,
+      "real_time": 5.4849741088535083e+01,
+      "cpu_time": 5.4849114311800349e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=1.039 size=21 num_sets=199729"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20972535,
+      "real_time": 5.5665634809273975e+01,
+      "cpu_time": 5.5663919693066376e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=321 num_sets=13067"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20996100,
+      "real_time": 6.3976304992954560e+01,
+      "cpu_time": 6.3975142145450150e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=5121 num_sets=820"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21299460,
+      "real_time": 6.6504933225493161e+01,
+      "cpu_time": 6.6504379078152567e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=81921 num_sets=52"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 20971536,
+      "real_time": 6.4731746714710582e+01,
+      "cpu_time": 6.4730627456191826e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=1310721 num_sets=4"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971535,
+      "real_time": 5.4927403928861054e+01,
+      "cpu_time": 5.4927260498568046e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.071 size=19 num_sets=220753"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20972655,
+      "real_time": 5.4270283776673416e+01,
+      "cpu_time": 5.4270483446189289e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.089 size=319 num_sets=13149"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20987900,
+      "real_time": 6.2488173782333874e+01,
+      "cpu_time": 6.2488369203203902e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=5119 num_sets=820"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21298940,
+      "real_time": 6.1743645711878600e+01,
+      "cpu_time": 6.1743777577665988e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=81919 num_sets=52"
+    },
+    {
+      "name": "BM<FindHit_Cold, folly::F14VectorSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 20971504,
+      "real_time": 6.7113745716679134e+01,
+      "cpu_time": 6.7113991490548003e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.090 size=1310719 num_sets=4"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 67108877,
+      "real_time": 2.2379072034652097e+01,
+      "cpu_time": 2.2379132540097764e+01,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=2.315 size=17 num_sets=3947581"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 67108868,
+      "real_time": 3.1324402536596569e+01,
+      "cpu_time": 3.1324376861789410e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.323 size=257 num_sets=261124"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 67112957,
+      "real_time": 2.9093074796749473e+01,
+      "cpu_time": 2.9092636955334850e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.324 size=4097 num_sets=16381"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 67109888,
+      "real_time": 3.0876145686292670e+01,
+      "cpu_time": 3.0875768724273417e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.324 size=65537 num_sets=1024"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67108928,
+      "real_time": 3.0591816326619302e+01,
+      "cpu_time": 3.0590980755942770e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.323 size=1048577 num_sets=64"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 67108893,
+      "real_time": 2.4894308737036884e+01,
+      "cpu_time": 2.4894360677352594e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=2.751 size=31 num_sets=2164803"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 67109119,
+      "real_time": 3.1429843205505200e+01,
+      "cpu_time": 3.1429910918664291e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.861 size=511 num_sets=131329"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 67117054,
+      "real_time": 3.3695622327528149e+01,
+      "cpu_time": 3.3695316618038909e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.869 size=8191 num_sets=8194"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 67239423,
+      "real_time": 3.5654035112421063e+01,
+      "cpu_time": 3.5654134822067483e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.869 size=131071 num_sets=513"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 69205983,
+      "real_time": 3.5621214128987567e+01,
+      "cpu_time": 3.5621220032375930e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.866 size=2097151 num_sets=33"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971540,
+      "real_time": 4.3006041237183403e+01,
+      "cpu_time": 4.3005820554904652e+01,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=2.315 size=17 num_sets=246724"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20972485,
+      "real_time": 3.6099400944674272e+01,
+      "cpu_time": 3.6098169053406551e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.323 size=257 num_sets=16321"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20976640,
+      "real_time": 5.6961525394359626e+01,
+      "cpu_time": 5.6961376083112562e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.324 size=4097 num_sets=1024"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971840,
+      "real_time": 3.7824989160059580e+01,
+      "cpu_time": 3.7825270314860731e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.324 size=65537 num_sets=64"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 20971540,
+      "real_time": 4.0912647909844331e+01,
+      "cpu_time": 4.0912398946384883e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.322 size=1048577 num_sets=4"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971655,
+      "real_time": 4.8308875716600845e+01,
+      "cpu_time": 4.8308929457402712e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=2.751 size=31 num_sets=135301"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20973995,
+      "real_time": 4.8581747223848282e+01,
+      "cpu_time": 4.8581868880956961e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.862 size=511 num_sets=8209"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 21009915,
+      "real_time": 5.0695019339986366e+01,
+      "cpu_time": 5.0694974729783382e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.869 size=8191 num_sets=513"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21626715,
+      "real_time": 5.0234597828104825e+01,
+      "cpu_time": 5.0234332999718539e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.869 size=131071 num_sets=33"
+    },
+    {
+      "name": "BM<FindHit_Cold, google::dense_hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 25165812,
+      "real_time": 5.3761972233972813e+01,
+      "cpu_time": 5.3760756338793399e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.866 size=2097151 num_sets=3"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33399808,
+      "real_time": 9.3121121679467951e+00,
+      "cpu_time": 9.3121739202826070e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.498 size=194 num_sets=338"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33486336,
+      "real_time": 9.3780522223246390e+00,
+      "cpu_time": 9.3779506662118308e+00,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=0.508 size=390 num_sets=169"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33549824,
+      "real_time": 9.1751483305491668e+00,
+      "cpu_time": 9.1752101292695052e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.496 size=6152 num_sets=11"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 9.3908809617460065e+00,
+      "cpu_time": 9.3909212648814560e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.503 size=98318 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 9.8145278570882510e+00,
+      "cpu_time": 9.8144749999080840e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.501 size=1572870 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33444864,
+      "real_time": 9.8502239873538411e+00,
+      "cpu_time": 9.8502832303310619e+00,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=0.999 size=192 num_sets=342"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33486336,
+      "real_time": 9.7800618130965749e+00,
+      "cpu_time": 9.7801472517036849e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.995 size=388 num_sets=169"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33549824,
+      "real_time": 1.0319691428985076e+01,
+      "cpu_time": 1.0319277233762344e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.997 size=6150 num_sets=11"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 9.7746593041847518e+00,
+      "cpu_time": 9.7747228145592828e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.006 size=98316 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.0317251053493237e+01,
+      "cpu_time": 1.0317305147653215e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.006 size=1572868 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33399808,
+      "real_time": 9.9388639643552139e+00,
+      "cpu_time": 9.9387673725557839e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.503 size=194 num_sets=338"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33486336,
+      "real_time": 9.5670635856284409e+00,
+      "cpu_time": 9.5669171748147157e+00,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=0.506 size=390 num_sets=169"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33549824,
+      "real_time": 9.2879056312910269e+00,
+      "cpu_time": 9.2879683362916694e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.504 size=6152 num_sets=11"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.0139082462501392e+01,
+      "cpu_time": 1.0139037191870074e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.501 size=98318 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.0520459170493268e+01,
+      "cpu_time": 1.0517935395243882e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.502 size=1572870 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33444864,
+      "real_time": 9.5895557495213364e+00,
+      "cpu_time": 9.5894738875269372e+00,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=1.000 size=192 num_sets=342"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33486336,
+      "real_time": 9.6753996275175673e+00,
+      "cpu_time": 9.6754621049002658e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.995 size=388 num_sets=169"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33549824,
+      "real_time": 9.8989426103663494e+00,
+      "cpu_time": 9.8989135382631375e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.994 size=6150 num_sets=11"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.0097622293869790e+01,
+      "cpu_time": 1.0097714841367234e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.994 size=98316 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.0274213479988248e+01,
+      "cpu_time": 1.0274147152903906e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.007 size=1572868 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 31588352,
+      "real_time": 1.2032539427717104e+01,
+      "cpu_time": 1.2032611261270214e+01,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=0.000 size=17 num_sets=3856"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.2874473043211765e+01,
+      "cpu_time": 1.2874324649571724e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=0.000 size=257 num_sets=256"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.3450453195673617e+01,
+      "cpu_time": 1.3450566768649782e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=4349 num_sets=16"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.3722868175136682e+01,
+      "cpu_time": 1.3722796857354544e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=67307 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.2983768726826383e+01,
+      "cpu_time": 1.2983216941361732e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=1056323 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 32605184,
+      "real_time": 1.6612595486631946e+01,
+      "cpu_time": 1.6612591145015216e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=35 num_sets=1873"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33543168,
+      "real_time": 1.7524498749133027e+01,
+      "cpu_time": 1.7524653634385821e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=539 num_sets=122"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.6841354977259471e+01,
+      "cpu_time": 1.6841372847554016e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=4347 num_sets=16"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.7693587039957492e+01,
+      "cpu_time": 1.7693735361098287e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=67305 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.7364421012189268e+01,
+      "cpu_time": 1.7362570255994104e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1056321 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 31588352,
+      "real_time": 1.2053710652932649e+01,
+      "cpu_time": 1.2053683997186113e+01,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=0.000 size=17 num_sets=3856"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.2313165598243359e+01,
+      "cpu_time": 1.2313157171010923e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=0.000 size=257 num_sets=256"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.2429488549514645e+01,
+      "cpu_time": 1.2429571688170110e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=4349 num_sets=16"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.3043496949194378e+01,
+      "cpu_time": 1.3043515264987596e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=67307 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.2943949911914387e+01,
+      "cpu_time": 1.2944033384321163e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=1056323 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 32605184,
+      "real_time": 1.6433963540593179e+01,
+      "cpu_time": 1.6433849016156149e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=35 num_sets=1873"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33543168,
+      "real_time": 1.6769847984471468e+01,
+      "cpu_time": 1.6768720175747315e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=539 num_sets=122"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.6687849324625859e+01,
+      "cpu_time": 1.6687787294390581e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=4347 num_sets=16"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.6745808295581810e+01,
+      "cpu_time": 1.6745275735854158e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=67305 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, std::unordered_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.8233379250887083e+01,
+      "cpu_time": 1.8233506947758173e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1056321 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 31959040,
+      "real_time": 2.1640418436961921e+00,
+      "cpu_time": 2.1640474494793942e+00,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.000 size=21 num_sets=3121"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33482240,
+      "real_time": 2.2045834475185577e+00,
+      "cpu_time": 2.2044389503221962e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=321 num_sets=205"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33552896,
+      "real_time": 2.1437842521612471e+00,
+      "cpu_time": 2.1437942942371842e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=5121 num_sets=13"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.0579449255819782e+00,
+      "cpu_time": 2.0579572021996890e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=81921 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.1302284380908532e+00,
+      "cpu_time": 2.1302147209614786e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 31795200,
+      "real_time": 2.1743757617262442e+00,
+      "cpu_time": 2.1743987142732464e+00,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=19 num_sets=3450"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33540096,
+      "real_time": 2.7045076991049095e+00,
+      "cpu_time": 2.7045364449734310e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=319 num_sets=206"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33552896,
+      "real_time": 2.7319487148643664e+00,
+      "cpu_time": 2.7319669217223344e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=5119 num_sets=13"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.8766677928615536e+00,
+      "cpu_time": 2.8766892850418762e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=81919 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.8834250542786322e+00,
+      "cpu_time": 2.8834130764060539e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1310719 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 32219136,
+      "real_time": 2.0997825382003157e+00,
+      "cpu_time": 2.0997309487150257e+00,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.000 size=25 num_sets=2622"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33532416,
+      "real_time": 2.1093582484673830e+00,
+      "cpu_time": 2.1081131762180161e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=385 num_sets=171"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33549824,
+      "real_time": 2.0290344754785101e+00,
+      "cpu_time": 2.0290427454989333e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=6145 num_sets=11"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.0312853621362592e+00,
+      "cpu_time": 2.0312949121007025e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=98305 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.4124489073074074e+00,
+      "cpu_time": 2.4124666750432033e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 32102400,
+      "real_time": 2.3876838207815254e+00,
+      "cpu_time": 2.3876887709384143e+00,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.000 size=23 num_sets=2850"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33552384,
+      "real_time": 3.0127642918970459e+00,
+      "cpu_time": 3.0128243048220438e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=383 num_sets=172"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33549824,
+      "real_time": 2.9806316186335065e+00,
+      "cpu_time": 2.9805807028944029e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=6143 num_sets=11"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.9191440376052924e+00,
+      "cpu_time": 2.9191454350944590e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=98303 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14ValueSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 3.3327225423818163e+00,
+      "cpu_time": 3.3327475488137459e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1572863 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 32219136,
+      "real_time": 2.1907421832484140e+00,
+      "cpu_time": 2.1906253165800811e+00,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.000 size=25 num_sets=2622"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33532416,
+      "real_time": 2.2492990888135411e+00,
+      "cpu_time": 2.2493191662662033e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=385 num_sets=171"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33549824,
+      "real_time": 2.2250219713605150e+00,
+      "cpu_time": 2.2250391537099499e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=6145 num_sets=11"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.2618564798904117e+00,
+      "cpu_time": 2.2618689239021617e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=98305 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.2357156126417976e+00,
+      "cpu_time": 2.2357009947233766e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 32102400,
+      "real_time": 2.2687433819261273e+00,
+      "cpu_time": 2.2687465111614356e+00,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.000 size=23 num_sets=2850"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33552384,
+      "real_time": 2.9554342048250990e+00,
+      "cpu_time": 2.9553023713605282e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=383 num_sets=172"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33549824,
+      "real_time": 2.9472741616673317e+00,
+      "cpu_time": 2.9472956698659925e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=6143 num_sets=11"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.9890117048125830e+00,
+      "cpu_time": 2.9890269041005375e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=98303 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 3.0214195589906012e+00,
+      "cpu_time": 3.0213931202937205e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1572863 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 32219136,
+      "real_time": 2.0482717922533737e+00,
+      "cpu_time": 2.0482717165306874e+00,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.000 size=25 num_sets=2622"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33532416,
+      "real_time": 2.0030339254038503e+00,
+      "cpu_time": 2.0030446657949308e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=385 num_sets=171"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33549824,
+      "real_time": 2.0890125191075075e+00,
+      "cpu_time": 2.0890427920007792e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=6145 num_sets=11"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.2509212271870638e+00,
+      "cpu_time": 2.2509662807001218e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=98305 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.1702604158235772e+00,
+      "cpu_time": 2.1702299118022306e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 32102400,
+      "real_time": 2.2762370380488308e+00,
+      "cpu_time": 2.2762281947806966e+00,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.000 size=23 num_sets=2850"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33552384,
+      "real_time": 2.9290146133856467e+00,
+      "cpu_time": 2.9290427172011499e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=383 num_sets=172"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33549824,
+      "real_time": 2.9344115717421557e+00,
+      "cpu_time": 2.9343049906909831e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=6143 num_sets=11"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.8148079422862793e+00,
+      "cpu_time": 2.8148199021814304e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=98303 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14NodeSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 3.0585241006519936e+00,
+      "cpu_time": 3.0585198700409064e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1572863 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 31959040,
+      "real_time": 2.1777237213143015e+00,
+      "cpu_time": 2.1758434546218415e+00,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.000 size=21 num_sets=3121"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33482240,
+      "real_time": 2.2978438784363564e+00,
+      "cpu_time": 2.2978589843418562e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=321 num_sets=205"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33552896,
+      "real_time": 2.2045455429272502e+00,
+      "cpu_time": 2.2045595110450926e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=5121 num_sets=13"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.2401280830308679e+00,
+      "cpu_time": 2.2401385307282626e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=81921 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.2156498857839324e+00,
+      "cpu_time": 2.2156434655181378e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 31795200,
+      "real_time": 2.3361949337085473e+00,
+      "cpu_time": 2.3362044270772437e+00,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=19 num_sets=3450"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33540096,
+      "real_time": 2.8465774690281624e+00,
+      "cpu_time": 2.8465925678918187e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=319 num_sets=206"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33552896,
+      "real_time": 2.9245856687488643e+00,
+      "cpu_time": 2.9246055243607874e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=5119 num_sets=13"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.9842865956197784e+00,
+      "cpu_time": 2.9843078255654771e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=81919 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.8807889407289622e+00,
+      "cpu_time": 2.8800811767627126e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1310719 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 31959040,
+      "real_time": 1.9799109258280470e+00,
+      "cpu_time": 1.9799269314733590e+00,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.000 size=21 num_sets=3121"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33482240,
+      "real_time": 1.9456018584156831e+00,
+      "cpu_time": 1.9456109268674264e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=321 num_sets=205"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33552896,
+      "real_time": 1.9534282448719880e+00,
+      "cpu_time": 1.9534402633966585e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=5121 num_sets=13"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.9390924421713862e+00,
+      "cpu_time": 1.9391022920668082e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=81921 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.1388828486124112e+00,
+      "cpu_time": 2.1388804018527110e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 31795200,
+      "real_time": 2.2011456618178484e+00,
+      "cpu_time": 2.2011583823992806e+00,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=19 num_sets=3450"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33540096,
+      "real_time": 2.7478622236101593e+00,
+      "cpu_time": 2.7478838760572155e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=319 num_sets=206"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33552896,
+      "real_time": 2.5735188541558172e+00,
+      "cpu_time": 2.5735299271925838e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=5119 num_sets=13"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.6890845106208872e+00,
+      "cpu_time": 2.6889864206345040e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=81919 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, folly::F14VectorSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.7613751285571198e+00,
+      "cpu_time": 2.7613762021070061e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1310719 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 31588352,
+      "real_time": 2.8619798131217538e+00,
+      "cpu_time": 2.8610216196142164e+00,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=1.779 size=17 num_sets=3856"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.7725235440811957e+00,
+      "cpu_time": 2.7725368738183578e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.735 size=257 num_sets=256"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.9263773626553302e+00,
+      "cpu_time": 2.9263967275632279e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.739 size=4097 num_sets=16"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.7840627581099398e+00,
+      "cpu_time": 2.7840775251332643e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.719 size=65537 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.7831745796902396e+00,
+      "cpu_time": 2.7789043188078724e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.719 size=1048577 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 32486400,
+      "real_time": 3.3302818277485264e+00,
+      "cpu_time": 3.3302983094423926e+00,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=3.055 size=31 num_sets=2115"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33552384,
+      "real_time": 3.4345326754066421e+00,
+      "cpu_time": 3.4345521617825723e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=3.318 size=511 num_sets=129"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33550848,
+      "real_time": 3.4739586985672091e+00,
+      "cpu_time": 3.4739811047447327e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=3.344 size=8191 num_sets=9"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 3.4703973028626933e+00,
+      "cpu_time": 3.4697157144574571e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=3.335 size=131071 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 3.5627323313747183e+00,
+      "cpu_time": 3.5627401471103530e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=3.311 size=2097151 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 31588352,
+      "real_time": 2.7649620131500590e+00,
+      "cpu_time": 2.7643503845988300e+00,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=1.769 size=17 num_sets=3856"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.7173143735126359e+00,
+      "cpu_time": 2.7173351347441828e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.744 size=257 num_sets=256"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.6710580414146534e+00,
+      "cpu_time": 2.6710695624315415e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.738 size=4097 num_sets=16"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.7251303436059970e+00,
+      "cpu_time": 2.7251420617105113e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.721 size=65537 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 2.8727242806780851e+00,
+      "cpu_time": 2.8727193474768851e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.738 size=1048577 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 32486400,
+      "real_time": 3.8039206378191261e+00,
+      "cpu_time": 3.8021436047042996e+00,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=3.057 size=31 num_sets=2115"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33552384,
+      "real_time": 3.8350118991656741e+00,
+      "cpu_time": 3.8350365506029811e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=3.302 size=511 num_sets=129"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33550848,
+      "real_time": 3.9276886989426023e+00,
+      "cpu_time": 3.9277145245372389e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=3.315 size=8191 num_sets=9"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 3.9554706177113985e+00,
+      "cpu_time": 3.9556534290309204e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=3.333 size=131071 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Hot, google::dense_hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.1398280359317141e+00,
+      "cpu_time": 4.1387084424526437e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=3.306 size=2097151 num_sets=1"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 67108868,
+      "real_time": 6.0979679890247731e+01,
+      "cpu_time": 6.0978214414224936e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.499 size=194 num_sets=345922"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 67109250,
+      "real_time": 8.4264206549762633e+01,
+      "cpu_time": 8.4264604819751398e+01,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=0.507 size=390 num_sets=172075"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 67112168,
+      "real_time": 6.0675554036608155e+01,
+      "cpu_time": 6.0675312888117567e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.501 size=6152 num_sets=10909"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 67151194,
+      "real_time": 6.3645597412841248e+01,
+      "cpu_time": 6.3645111492731118e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.500 size=98318 num_sets=683"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67633410,
+      "real_time": 6.6114703700378854e+01,
+      "cpu_time": 6.6114840283818353e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.500 size=1572870 num_sets=43"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 67108992,
+      "real_time": 9.2460469007930897e+01,
+      "cpu_time": 9.2459919395005485e+01,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=0.995 size=192 num_sets=349526"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 67108868,
+      "real_time": 8.7730148579127658e+01,
+      "cpu_time": 8.7729795263420669e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.997 size=388 num_sets=172961"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 67114950,
+      "real_time": 9.1856574684392342e+01,
+      "cpu_time": 9.1855458910423280e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=6150 num_sets=10913"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 67149828,
+      "real_time": 8.6090875782204677e+01,
+      "cpu_time": 8.6090380886752953e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=98316 num_sets=683"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 67633324,
+      "real_time": 9.9013760770497342e+01,
+      "cpu_time": 9.9011916803025272e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=1572868 num_sets=43"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20972370,
+      "real_time": 5.4213077439630709e+01,
+      "cpu_time": 5.4211001141024028e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.499 size=194 num_sets=21621"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20972250,
+      "real_time": 5.4199131805332975e+01,
+      "cpu_time": 5.4199002443710917e+01,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=0.507 size=390 num_sets=10755"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20978320,
+      "real_time": 5.7823215327349381e+01,
+      "cpu_time": 5.7820770633680524e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.501 size=6152 num_sets=682"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21138370,
+      "real_time": 5.7371204382123651e+01,
+      "cpu_time": 5.7370548154846304e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.500 size=98318 num_sets=43"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 23593050,
+      "real_time": 5.9718043173876119e+01,
+      "cpu_time": 5.9717800877800038e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.500 size=1572870 num_sets=3"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20972160,
+      "real_time": 7.1879424582890024e+01,
+      "cpu_time": 7.1871860361542090e+01,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=0.994 size=192 num_sets=21846"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20973340,
+      "real_time": 7.0872408582809030e+01,
+      "cpu_time": 7.0870958988894003e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.998 size=388 num_sets=10811"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 21002250,
+      "real_time": 7.5367186705174916e+01,
+      "cpu_time": 7.5367017295766701e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=6150 num_sets=683"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21137940,
+      "real_time": 7.5397726675559213e+01,
+      "cpu_time": 7.5395755262814077e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=98316 num_sets=43"
+    },
+    {
+      "name": "BM<FindMiss_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 23593020,
+      "real_time": 8.6617670219509208e+01,
+      "cpu_time": 8.6617593720509049e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=1572868 num_sets=3"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 67108877,
+      "real_time": 6.8179550120977424e+01,
+      "cpu_time": 6.8179002175822347e+01,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=0.000 size=17 num_sets=3947581"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 67108868,
+      "real_time": 1.1776250738745722e+02,
+      "cpu_time": 1.1776314395587768e+02,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=0.000 size=257 num_sets=261124"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 67109419,
+      "real_time": 1.1881804131079862e+02,
+      "cpu_time": 1.1881751658437004e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=4349 num_sets=15431"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 67172386,
+      "real_time": 1.2510019503027118e+02,
+      "cpu_time": 1.2509936001082490e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=67307 num_sets=998"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67604672,
+      "real_time": 1.4235896600012723e+02,
+      "cpu_time": 1.4235822985725153e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=1056323 num_sets=64"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 67108895,
+      "real_time": 1.2192598272081857e+02,
+      "cpu_time": 1.2192524417217403e+02,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=35 num_sets=1917397"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 67109273,
+      "real_time": 1.6010530978892641e+02,
+      "cpu_time": 1.6010579828513039e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=539 num_sets=124507"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 67108986,
+      "real_time": 1.6531857982344022e+02,
+      "cpu_time": 1.6531771575270182e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=4347 num_sets=15438"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 67170390,
+      "real_time": 1.7723874276484972e+02,
+      "cpu_time": 1.7723927459703467e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=67305 num_sets=998"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 67604544,
+      "real_time": 1.7581710842324881e+02,
+      "cpu_time": 1.7581705271171825e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1056321 num_sets=64"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971540,
+      "real_time": 9.9068855541896241e+01,
+      "cpu_time": 9.9067335827503669e+01,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=0.000 size=17 num_sets=246724"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20972485,
+      "real_time": 1.0808628895099788e+02,
+      "cpu_time": 1.0808630140870991e+02,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=0.000 size=257 num_sets=16321"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20983925,
+      "real_time": 1.2266459315668170e+02,
+      "cpu_time": 1.2266306179611398e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=4349 num_sets=965"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21201705,
+      "real_time": 1.2222609346728717e+02,
+      "cpu_time": 1.2222553355968178e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=67307 num_sets=63"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 21126460,
+      "real_time": 1.2416570594012302e+02,
+      "cpu_time": 1.2416620176783429e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=1056323 num_sets=4"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971650,
+      "real_time": 1.6113630339187418e+02,
+      "cpu_time": 1.6113532855069593e+02,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=35 num_sets=119838"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20972490,
+      "real_time": 1.7228342209392588e+02,
+      "cpu_time": 1.7228148121658410e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=539 num_sets=7782"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20974275,
+      "real_time": 1.8556229145654135e+02,
+      "cpu_time": 1.8556051134067525e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=4347 num_sets=965"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21201075,
+      "real_time": 1.8486451954950320e+02,
+      "cpu_time": 1.8486370153400395e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=67305 num_sets=63"
+    },
+    {
+      "name": "BM<FindMiss_Cold, std::unordered_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 21126420,
+      "real_time": 1.8703560047581408e+02,
+      "cpu_time": 1.8703340783720097e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1056321 num_sets=4"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 67108881,
+      "real_time": 1.5820716725772774e+01,
+      "cpu_time": 1.5820705831766315e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.000 size=21 num_sets=3195661"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 67108902,
+      "real_time": 1.9863246457863770e+01,
+      "cpu_time": 1.9862901988766595e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=321 num_sets=209062"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 67110705,
+      "real_time": 2.1364396581613907e+01,
+      "cpu_time": 2.1364413158827197e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=5121 num_sets=13105"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 67175220,
+      "real_time": 2.2998084278729525e+01,
+      "cpu_time": 2.2997647674245830e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=81921 num_sets=820"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 68157492,
+      "real_time": 2.3659048914960778e+01,
+      "cpu_time": 2.3659091681366242e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1310721 num_sets=52"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 67108874,
+      "real_time": 1.4111920194548471e+01,
+      "cpu_time": 1.4111960409288345e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=19 num_sets=3532046"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 67108987,
+      "real_time": 3.6080420024593870e+01,
+      "cpu_time": 3.6079812484732678e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=319 num_sets=210373"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 67110090,
+      "real_time": 4.0226386300916850e+01,
+      "cpu_time": 4.0226018665748839e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=5119 num_sets=13110"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 67173580,
+      "real_time": 4.5479322201446294e+01,
+      "cpu_time": 4.5477963866150098e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=81919 num_sets=820"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 68157388,
+      "real_time": 4.6173689010235584e+01,
+      "cpu_time": 4.6173051878102640e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1310719 num_sets=52"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971625,
+      "real_time": 2.2431051108037813e+01,
+      "cpu_time": 2.2431220708934500e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.000 size=25 num_sets=167773"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20972875,
+      "real_time": 2.0417302979593853e+01,
+      "cpu_time": 2.0417468420519558e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=385 num_sets=10895"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20985175,
+      "real_time": 2.2079000979088232e+01,
+      "cpu_time": 2.2079149351845736e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=6145 num_sets=683"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21135575,
+      "real_time": 2.3211174167306634e+01,
+      "cpu_time": 2.3210265441103747e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=98305 num_sets=43"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 23592975,
+      "real_time": 2.4399099906899259e+01,
+      "cpu_time": 2.4399283515543434e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1572865 num_sets=3"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971630,
+      "real_time": 2.0890006020477593e+01,
+      "cpu_time": 2.0890154222634543e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.000 size=23 num_sets=182362"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20973080,
+      "real_time": 3.0009671755685730e+01,
+      "cpu_time": 3.0008829652103039e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=383 num_sets=10952"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20978345,
+      "real_time": 3.5141795553667912e+01,
+      "cpu_time": 3.5141657647439430e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=6143 num_sets=683"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21135145,
+      "real_time": 3.8628169905903100e+01,
+      "cpu_time": 3.8625164151922114e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=98303 num_sets=43"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14ValueSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 23592945,
+      "real_time": 3.9692374909446826e+01,
+      "cpu_time": 3.9692500491131966e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1572863 num_sets=3"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 67108875,
+      "real_time": 2.4192693657501856e+01,
+      "cpu_time": 2.4192221401420390e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.000 size=25 num_sets=2684355"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 67108965,
+      "real_time": 2.5804315373017552e+01,
+      "cpu_time": 2.5804068279106463e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=385 num_sets=174309"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 67109545,
+      "real_time": 2.7661304324179909e+01,
+      "cpu_time": 2.7661285604013390e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=6145 num_sets=10921"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 67142315,
+      "real_time": 2.7546697713647308e+01,
+      "cpu_time": 2.7546039945151193e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=98305 num_sets=683"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67633195,
+      "real_time": 2.6213020133091707e+01,
+      "cpu_time": 2.6212998942314886e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1572865 num_sets=43"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 67108871,
+      "real_time": 2.6083509518261472e+01,
+      "cpu_time": 2.6083166486291184e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.000 size=23 num_sets=2917777"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 67108877,
+      "real_time": 4.8400733593126418e+01,
+      "cpu_time": 4.8400456395651133e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=383 num_sets=175219"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 67112275,
+      "real_time": 5.1772411438720411e+01,
+      "cpu_time": 5.1772264179688250e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=6143 num_sets=10925"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 67140949,
+      "real_time": 5.4859932653691658e+01,
+      "cpu_time": 5.4858166273464654e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=98303 num_sets=683"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 67633109,
+      "real_time": 6.3539814935013553e+01,
+      "cpu_time": 6.3534474527855700e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1572863 num_sets=43"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971625,
+      "real_time": 1.9603309813927805e+01,
+      "cpu_time": 1.9603768806667883e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.000 size=25 num_sets=167773"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20972875,
+      "real_time": 1.9864070360291223e+01,
+      "cpu_time": 1.9864232061654942e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=385 num_sets=10895"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20985175,
+      "real_time": 2.2072513684668863e+01,
+      "cpu_time": 2.2070312494431786e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=6145 num_sets=683"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21135575,
+      "real_time": 2.0668269769742391e+01,
+      "cpu_time": 2.0668432252262935e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=98305 num_sets=43"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 23592975,
+      "real_time": 2.4188380223967126e+01,
+      "cpu_time": 2.4188072763180777e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1572865 num_sets=3"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971630,
+      "real_time": 2.0581416086784657e+01,
+      "cpu_time": 2.0580912356368955e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.000 size=23 num_sets=182362"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20973080,
+      "real_time": 2.4138967728237258e+01,
+      "cpu_time": 2.4139142271911741e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=383 num_sets=10952"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20978345,
+      "real_time": 2.8530147260925631e+01,
+      "cpu_time": 2.8528829943462625e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=6143 num_sets=683"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21135145,
+      "real_time": 2.8159144860879515e+01,
+      "cpu_time": 2.8159097749269595e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=98303 num_sets=43"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14NodeSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 23592945,
+      "real_time": 3.5210473119063600e+01,
+      "cpu_time": 3.5210548746656031e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1572863 num_sets=3"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 67108881,
+      "real_time": 1.8016129798300788e+01,
+      "cpu_time": 1.8015842508236954e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.000 size=21 num_sets=3195661"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 67108902,
+      "real_time": 2.4246894751356471e+01,
+      "cpu_time": 2.4246363097997616e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=321 num_sets=209062"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 67110705,
+      "real_time": 2.5927398169952479e+01,
+      "cpu_time": 2.5926568019217431e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=5121 num_sets=13105"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 67175220,
+      "real_time": 2.6818699771526397e+01,
+      "cpu_time": 2.6818029445981530e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=81921 num_sets=820"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 68157492,
+      "real_time": 2.7078396579217223e+01,
+      "cpu_time": 2.7077794763923691e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1310721 num_sets=52"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 67108874,
+      "real_time": 1.7728884161260446e+01,
+      "cpu_time": 1.7728746424806186e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=19 num_sets=3532046"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 67108987,
+      "real_time": 3.9525338056386261e+01,
+      "cpu_time": 3.9525198465592069e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=319 num_sets=210373"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 67110090,
+      "real_time": 4.3416586743569553e+01,
+      "cpu_time": 4.3416209768156911e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=5119 num_sets=13110"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 67173580,
+      "real_time": 4.8125606092004489e+01,
+      "cpu_time": 4.8125119354960304e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=81919 num_sets=820"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 68157388,
+      "real_time": 4.8860971557741394e+01,
+      "cpu_time": 4.8861066022654057e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1310719 num_sets=52"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971545,
+      "real_time": 1.7313950417027545e+01,
+      "cpu_time": 1.7313826425299560e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.000 size=21 num_sets=199729"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20972535,
+      "real_time": 1.6015517513114848e+01,
+      "cpu_time": 1.6015646177269275e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=321 num_sets=13067"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20996100,
+      "real_time": 1.6627515944309206e+01,
+      "cpu_time": 1.6627090173882035e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=5121 num_sets=820"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21299460,
+      "real_time": 1.6766948608915502e+01,
+      "cpu_time": 1.6766674225554972e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=81921 num_sets=52"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 20971536,
+      "real_time": 1.8915110679568102e+01,
+      "cpu_time": 1.8915249364662770e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1310721 num_sets=4"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971535,
+      "real_time": 1.3086528004656072e+01,
+      "cpu_time": 1.3086380610663703e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=19 num_sets=220753"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20972655,
+      "real_time": 1.7192998622336013e+01,
+      "cpu_time": 1.7191326324681349e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=319 num_sets=13149"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20987900,
+      "real_time": 1.9774909223469702e+01,
+      "cpu_time": 1.9774060291878808e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=5119 num_sets=820"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21298940,
+      "real_time": 1.9199001487271417e+01,
+      "cpu_time": 1.9197140514976272e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=81919 num_sets=52"
+    },
+    {
+      "name": "BM<FindMiss_Cold, folly::F14VectorSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 20971504,
+      "real_time": 2.2349371418396537e+01,
+      "cpu_time": 2.2349244050413162e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1310719 num_sets=4"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 67108877,
+      "real_time": 1.9110149757753774e+01,
+      "cpu_time": 1.9109956571016024e+01,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=1.771 size=17 num_sets=3947581"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 67108868,
+      "real_time": 2.6923876633206255e+01,
+      "cpu_time": 2.6923859585889936e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.734 size=257 num_sets=261124"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 67112957,
+      "real_time": 2.4279697127443058e+01,
+      "cpu_time": 2.4279685888374015e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.731 size=4097 num_sets=16381"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 67109888,
+      "real_time": 2.6113585402515280e+01,
+      "cpu_time": 2.6113016087879853e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.731 size=65537 num_sets=1024"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67108928,
+      "real_time": 2.6290155626860518e+01,
+      "cpu_time": 2.6290132722725218e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.731 size=1048577 num_sets=64"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 67108893,
+      "real_time": 2.7016396991063811e+01,
+      "cpu_time": 2.7015988432413131e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=3.071 size=31 num_sets=2164803"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 67109119,
+      "real_time": 3.9114525539063344e+01,
+      "cpu_time": 3.9114266125292410e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=3.309 size=511 num_sets=131329"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 67117054,
+      "real_time": 4.1472007625603183e+01,
+      "cpu_time": 4.1471848034331501e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=3.328 size=8191 num_sets=8194"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 67239423,
+      "real_time": 4.3894985156290879e+01,
+      "cpu_time": 4.3894786084053592e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=3.328 size=131071 num_sets=513"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 69205983,
+      "real_time": 4.4765450473708682e+01,
+      "cpu_time": 4.4765015764605046e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=3.327 size=2097151 num_sets=33"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971540,
+      "real_time": 4.3379934152510181e+01,
+      "cpu_time": 4.3379785652364212e+01,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=1.772 size=17 num_sets=246724"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20972485,
+      "real_time": 3.5165688436312593e+01,
+      "cpu_time": 3.5165954153733146e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.733 size=257 num_sets=16321"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20976640,
+      "real_time": 3.7020867954587715e+01,
+      "cpu_time": 3.7020610116761020e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.730 size=4097 num_sets=1024"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971840,
+      "real_time": 3.7421975469837342e+01,
+      "cpu_time": 3.7421860122894586e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.732 size=65537 num_sets=64"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 20971540,
+      "real_time": 3.9010418817825737e+01,
+      "cpu_time": 3.9010459889923574e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.730 size=1048577 num_sets=4"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971655,
+      "real_time": 6.0873577825654131e+01,
+      "cpu_time": 6.0873107344180703e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=3.067 size=31 num_sets=135301"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20973995,
+      "real_time": 5.8119549824206651e+01,
+      "cpu_time": 5.8118027681408293e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=3.308 size=511 num_sets=8209"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 21009915,
+      "real_time": 6.0231903218106062e+01,
+      "cpu_time": 6.0229966518184000e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=3.325 size=8191 num_sets=513"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21626715,
+      "real_time": 6.1117683436695302e+01,
+      "cpu_time": 6.1116958909399266e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=3.329 size=131071 num_sets=33"
+    },
+    {
+      "name": "BM<FindMiss_Cold, google::dense_hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 25165812,
+      "real_time": 6.3706723631795029e+01,
+      "cpu_time": 6.3706740239485335e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=3.328 size=2097151 num_sets=3"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33572864,
+      "real_time": 1.0809361119293014e+01,
+      "cpu_time": 1.0809446790123738e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.247 size=194 num_sets=338"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33745920,
+      "real_time": 1.0458776534300005e+01,
+      "cpu_time": 1.0458874139462043e+01,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=1.255 size=390 num_sets=169"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34648064,
+      "real_time": 1.0600173113732660e+01,
+      "cpu_time": 1.0600150328751131e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.249 size=6152 num_sets=11"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.1065559135658987e+01,
+      "cpu_time": 1.1065638601782881e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.249 size=98318 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.1261221288805245e+01,
+      "cpu_time": 1.1260101407761878e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.250 size=1572870 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33619968,
+      "real_time": 1.0603538112529712e+01,
+      "cpu_time": 1.0603579218171994e+01,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=1.497 size=192 num_sets=342"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33572864,
+      "real_time": 1.0593986027463130e+01,
+      "cpu_time": 1.0594067131120914e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.498 size=388 num_sets=169"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34636800,
+      "real_time": 1.0685491357039982e+01,
+      "cpu_time": 1.0685450128191610e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.499 size=6150 num_sets=11"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.1330449467550352e+01,
+      "cpu_time": 1.1330538570876307e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.494 size=98316 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.2157357787145884e+01,
+      "cpu_time": 1.2157425522798583e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.500 size=1572868 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33572864,
+      "real_time": 1.0389469169457035e+01,
+      "cpu_time": 1.0388599197259159e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.251 size=194 num_sets=338"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33745920,
+      "real_time": 1.0519819069914311e+01,
+      "cpu_time": 1.0519884270457398e+01,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=1.255 size=390 num_sets=169"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34648064,
+      "real_time": 1.0457058923913733e+01,
+      "cpu_time": 1.0457174259430678e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.247 size=6152 num_sets=11"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.1210765649138921e+01,
+      "cpu_time": 1.1210630714893069e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.251 size=98318 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.1297260016362998e+01,
+      "cpu_time": 1.1297206819048281e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.250 size=1572870 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33619968,
+      "real_time": 1.0565576902872087e+01,
+      "cpu_time": 1.0565637837614284e+01,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=1.498 size=192 num_sets=342"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33572864,
+      "real_time": 1.0609424745797282e+01,
+      "cpu_time": 1.0609075412812098e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.494 size=388 num_sets=169"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34636800,
+      "real_time": 1.0479691783234708e+01,
+      "cpu_time": 1.0479756328532451e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.498 size=6150 num_sets=11"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.1296883428713045e+01,
+      "cpu_time": 1.1296981990334150e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.500 size=98316 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.2069762078681379e+01,
+      "cpu_time": 1.2069842755791337e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.495 size=1572868 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33562624,
+      "real_time": 1.2258871524165775e+01,
+      "cpu_time": 1.2258554635066808e+01,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=1.000 size=17 num_sets=3856"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33685504,
+      "real_time": 1.1802148239248602e+01,
+      "cpu_time": 1.1802101402430241e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.000 size=257 num_sets=256"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 35627008,
+      "real_time": 1.1972809929094881e+01,
+      "cpu_time": 1.1972805238089881e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.000 size=4349 num_sets=16"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.2894759038317716e+01,
+      "cpu_time": 1.2894846230750893e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=67307 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.3633822959491226e+01,
+      "cpu_time": 1.3633686542517589e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=1056323 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33564160,
+      "real_time": 1.4443832157169343e+01,
+      "cpu_time": 1.4443963054630029e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.000 size=35 num_sets=1873"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33668096,
+      "real_time": 1.4678655288733504e+01,
+      "cpu_time": 1.4678633742755238e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=539 num_sets=122"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 35610624,
+      "real_time": 1.4535090308666421e+01,
+      "cpu_time": 1.4535215838955752e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=4347 num_sets=16"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.5066568437305250e+01,
+      "cpu_time": 1.5066488504405216e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=67305 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.5033862155178213e+01,
+      "cpu_time": 1.5033843785527251e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=1056321 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33562624,
+      "real_time": 1.1804505108819521e+01,
+      "cpu_time": 1.1804604610166667e+01,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=1.000 size=17 num_sets=3856"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33685504,
+      "real_time": 1.1861884700594622e+01,
+      "cpu_time": 1.1861839413174570e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.000 size=257 num_sets=256"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 35627008,
+      "real_time": 1.1954359880677035e+01,
+      "cpu_time": 1.1954452981289204e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.000 size=4349 num_sets=16"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.3041862700902129e+01,
+      "cpu_time": 1.3041868895301507e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=67307 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.3294545908593136e+01,
+      "cpu_time": 1.3294417470683415e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=1056323 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33564160,
+      "real_time": 1.4363493065422709e+01,
+      "cpu_time": 1.4363581987453408e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.000 size=35 num_sets=1873"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33668096,
+      "real_time": 1.4758392295562864e+01,
+      "cpu_time": 1.4758398603820442e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=539 num_sets=122"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 35610624,
+      "real_time": 1.4469886212780033e+01,
+      "cpu_time": 1.4469992662863808e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=4347 num_sets=16"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.4624681909936044e+01,
+      "cpu_time": 1.4624677509064558e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=67305 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, std::unordered_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 1.4984394169914594e+01,
+      "cpu_time": 1.4984486341478487e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=1056321 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556992,
+      "real_time": 4.1436543643417281e+00,
+      "cpu_time": 4.1432758335431572e+00,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=1.039 size=21 num_sets=3121"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33692160,
+      "real_time": 4.0700162252333829e+00,
+      "cpu_time": 4.0700574555000575e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=321 num_sets=205"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34085376,
+      "real_time": 4.0920178852051503e+00,
+      "cpu_time": 4.0920495933601790e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.040 size=5121 num_sets=13"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.1769609993025369e+00,
+      "cpu_time": 4.1769914627001832e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.040 size=81921 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.3035441876781988e+00,
+      "cpu_time": 4.3035762608043635e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.038 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33561600,
+      "real_time": 3.9189712952148996e+00,
+      "cpu_time": 3.9190071689106416e+00,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.072 size=19 num_sets=3450"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33645568,
+      "real_time": 4.1545286162842805e+00,
+      "cpu_time": 4.1543006793641819e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=319 num_sets=206"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34072064,
+      "real_time": 4.0417093368974362e+00,
+      "cpu_time": 4.0417328401455279e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.090 size=5119 num_sets=13"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.4934864718015888e+00,
+      "cpu_time": 4.4935170411935506e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.090 size=81919 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.4433861035031441e+00,
+      "cpu_time": 4.4434011578535966e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=1310719 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33561600,
+      "real_time": 4.1718349645012305e+00,
+      "cpu_time": 4.1718632604023220e+00,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=1.047 size=25 num_sets=2622"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33707520,
+      "real_time": 4.1422458270637810e+00,
+      "cpu_time": 4.1422779545824886e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.046 size=385 num_sets=171"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34608640,
+      "real_time": 4.1911444774930739e+00,
+      "cpu_time": 4.1910452996762730e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=6145 num_sets=11"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.6024055677662545e+00,
+      "cpu_time": 4.6024259328913137e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=98305 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 5.1655746347023523e+00,
+      "cpu_time": 5.1655832231014411e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.046 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33561600,
+      "real_time": 4.3409222255309601e+00,
+      "cpu_time": 4.3408600603041849e+00,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=1.091 size=23 num_sets=2850"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33728512,
+      "real_time": 4.7897811436401243e+00,
+      "cpu_time": 4.7898248520467162e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.107 size=383 num_sets=172"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34597376,
+      "real_time": 4.8540053510440790e+00,
+      "cpu_time": 4.8540456073993941e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.110 size=6143 num_sets=11"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 5.2783093451580498e+00,
+      "cpu_time": 5.2783429026654085e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.108 size=98303 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14ValueSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 5.1188635552534834e+00,
+      "cpu_time": 5.1188827156944035e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.108 size=1572863 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33561600,
+      "real_time": 5.0793026100125225e+00,
+      "cpu_time": 5.0793358481150213e+00,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=1.047 size=25 num_sets=2622"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33707520,
+      "real_time": 5.0778618079433411e+00,
+      "cpu_time": 5.0779003023663849e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.046 size=385 num_sets=171"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34608640,
+      "real_time": 4.9364229848693659e+00,
+      "cpu_time": 4.9364735511090903e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.046 size=6145 num_sets=11"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 5.4246598324425577e+00,
+      "cpu_time": 5.4245650470163049e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.048 size=98305 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 5.6178635077230865e+00,
+      "cpu_time": 5.6178849637588195e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.046 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33561600,
+      "real_time": 5.3945528151514326e+00,
+      "cpu_time": 5.3945930468155217e+00,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=1.090 size=23 num_sets=2850"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33728512,
+      "real_time": 5.2483948824712430e+00,
+      "cpu_time": 5.2484183707834218e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.106 size=383 num_sets=172"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34597376,
+      "real_time": 5.3181023284614941e+00,
+      "cpu_time": 5.3181588395610122e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.110 size=6143 num_sets=11"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 6.0267879575803818e+00,
+      "cpu_time": 6.0243930518548252e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.108 size=98303 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 5.9196239021730435e+00,
+      "cpu_time": 5.9196553826336427e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.110 size=1572863 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33561600,
+      "real_time": 5.1343508070429982e+00,
+      "cpu_time": 5.1343723779497674e+00,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=1.047 size=25 num_sets=2622"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33707520,
+      "real_time": 4.8995899603652404e+00,
+      "cpu_time": 4.8996227844770139e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.046 size=385 num_sets=171"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34608640,
+      "real_time": 4.8578196075754638e+00,
+      "cpu_time": 4.8578591935411222e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.048 size=6145 num_sets=11"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 5.5201354598466423e+00,
+      "cpu_time": 5.5201781690096716e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=98305 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 5.6307101203856291e+00,
+      "cpu_time": 5.6307239830488163e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.046 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33561600,
+      "real_time": 5.0848933870241355e+00,
+      "cpu_time": 5.0848048662849603e+00,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=1.091 size=23 num_sets=2850"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33728512,
+      "real_time": 5.2554494997026042e+00,
+      "cpu_time": 5.2554876420284096e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.108 size=383 num_sets=172"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34597376,
+      "real_time": 5.2053548653972239e+00,
+      "cpu_time": 5.2053883508395709e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.110 size=6143 num_sets=11"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 5.6386397773167118e+00,
+      "cpu_time": 5.6386776566572179e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.110 size=98303 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14NodeSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 5.8854823237197706e+00,
+      "cpu_time": 5.8852356672376391e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.112 size=1572863 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556992,
+      "real_time": 5.0450511620825758e+00,
+      "cpu_time": 5.0450786828616314e+00,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=1.040 size=21 num_sets=3121"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33692160,
+      "real_time": 5.0651040739151183e+00,
+      "cpu_time": 5.0651334613169672e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.040 size=321 num_sets=205"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34085376,
+      "real_time": 5.0976106827132970e+00,
+      "cpu_time": 5.0975399831347383e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.038 size=5121 num_sets=13"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 5.2450630505518347e+00,
+      "cpu_time": 5.2450927197849424e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.040 size=81921 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 5.2507758141473460e+00,
+      "cpu_time": 5.2508066892707674e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33561600,
+      "real_time": 4.9306106740149902e+00,
+      "cpu_time": 4.9306527698239879e+00,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.070 size=19 num_sets=3450"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33645568,
+      "real_time": 5.0521209701312042e+00,
+      "cpu_time": 5.0521865762599116e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.090 size=319 num_sets=206"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34072064,
+      "real_time": 5.4789706924679002e+00,
+      "cpu_time": 5.4788973160002152e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=5119 num_sets=13"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 5.5140247923191055e+00,
+      "cpu_time": 5.5140496194375483e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.090 size=81919 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 5.5435478429899376e+00,
+      "cpu_time": 5.5435563623931108e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.090 size=1310719 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556992,
+      "real_time": 5.7276103877637095e+00,
+      "cpu_time": 5.7276547313936010e+00,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=1.039 size=21 num_sets=3121"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33692160,
+      "real_time": 5.6850446315804799e+00,
+      "cpu_time": 5.6849954410729255e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=321 num_sets=205"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34085376,
+      "real_time": 5.6185094865197547e+00,
+      "cpu_time": 5.6185417758003995e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.040 size=5121 num_sets=13"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 5.7930051866605936e+00,
+      "cpu_time": 5.7930333614294263e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.038 size=81921 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 5.9300262478245713e+00,
+      "cpu_time": 5.9300650358213662e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33561600,
+      "real_time": 5.6585767267315923e+00,
+      "cpu_time": 5.6584878253696864e+00,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.070 size=19 num_sets=3450"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33645568,
+      "real_time": 5.7034401952826714e+00,
+      "cpu_time": 5.7034727724031065e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.089 size=319 num_sets=206"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34072064,
+      "real_time": 5.6452518046186180e+00,
+      "cpu_time": 5.6452891729768844e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.089 size=5119 num_sets=13"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 6.0216294173187634e+00,
+      "cpu_time": 6.0216848552185853e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.090 size=81919 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, folly::F14VectorSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 6.0787428424191603e+00,
+      "cpu_time": 6.0787548124719306e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.090 size=1310719 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33562624,
+      "real_time": 4.5581343762207416e+00,
+      "cpu_time": 4.5581880606255867e+00,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=2.326 size=17 num_sets=3856"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33685504,
+      "real_time": 4.7221672694028465e+00,
+      "cpu_time": 4.7222026127399452e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.337 size=257 num_sets=256"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33562624,
+      "real_time": 4.5942140332599779e+00,
+      "cpu_time": 4.5942429292733769e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.333 size=4097 num_sets=16"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.4053436454305483e+00,
+      "cpu_time": 4.4052384495627983e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.325 size=65537 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.4175152424941189e+00,
+      "cpu_time": 4.4175261855092760e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.328 size=1048577 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33569280,
+      "real_time": 4.2212286248574733e+00,
+      "cpu_time": 4.2212737657789017e+00,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=2.758 size=31 num_sets=2115"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33750528,
+      "real_time": 4.2431485434285507e+00,
+      "cpu_time": 4.2431741512323446e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.866 size=511 num_sets=129"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 37744128,
+      "real_time": 4.3303991987134758e+00,
+      "cpu_time": 4.3304571508523528e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.875 size=8191 num_sets=9"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.9851109906740021e+00,
+      "cpu_time": 4.9851481616510194e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.879 size=131071 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 5.0710937671283318e+00,
+      "cpu_time": 5.0711124241335259e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.879 size=2097151 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33562624,
+      "real_time": 4.3783612160136238e+00,
+      "cpu_time": 4.3783779242062328e+00,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=2.328 size=17 num_sets=3856"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33685504,
+      "real_time": 4.5245485801561394e+00,
+      "cpu_time": 4.5245809592220612e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.337 size=257 num_sets=256"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33562624,
+      "real_time": 4.4484462517192958e+00,
+      "cpu_time": 4.4484778067398727e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.334 size=4097 num_sets=16"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.7187995733111165e+00,
+      "cpu_time": 4.7178766131436216e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.316 size=65537 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 4.9778350330598187e+00,
+      "cpu_time": 4.9781970679790062e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.317 size=1048577 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33569280,
+      "real_time": 5.2906835319193517e+00,
+      "cpu_time": 5.2906141269632307e+00,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=2.751 size=31 num_sets=2115"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33750528,
+      "real_time": 5.3023815676758694e+00,
+      "cpu_time": 5.3024147651817932e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.872 size=511 num_sets=129"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 37744128,
+      "real_time": 5.1795161547906821e+00,
+      "cpu_time": 5.1795514788436599e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.884 size=8191 num_sets=9"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 5.0263508910575183e+00,
+      "cpu_time": 5.0263652205510558e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.861 size=131071 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Hot, google::dense_hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 5.2253099624977040e+00,
+      "cpu_time": 5.2253348827355603e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.880 size=2097151 num_sets=1"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 67108868,
+      "real_time": 8.7569516192428807e+01,
+      "cpu_time": 8.7559487711814043e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.248 size=194 num_sets=345922"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 67109250,
+      "real_time": 8.5290330939498844e+01,
+      "cpu_time": 8.5290765773714341e+01,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=1.253 size=390 num_sets=172075"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 67112168,
+      "real_time": 1.3203116223344389e+02,
+      "cpu_time": 1.3202143398199107e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.250 size=6152 num_sets=10909"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 67151194,
+      "real_time": 9.3513606235349812e+01,
+      "cpu_time": 9.3509351166563121e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.250 size=98318 num_sets=683"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67633410,
+      "real_time": 9.5560733779095230e+01,
+      "cpu_time": 9.5543644819920303e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.249 size=1572870 num_sets=43"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 67108992,
+      "real_time": 9.4169107865643213e+01,
+      "cpu_time": 9.4169424493815441e+01,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=1.495 size=192 num_sets=349526"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 67108868,
+      "real_time": 9.5200339710300369e+01,
+      "cpu_time": 9.5196959811629128e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.497 size=388 num_sets=172961"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 67114950,
+      "real_time": 9.6774985074571902e+01,
+      "cpu_time": 9.6771826426153126e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.500 size=6150 num_sets=10913"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 67149828,
+      "real_time": 1.0213722576909278e+02,
+      "cpu_time": 1.0213446917540718e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.500 size=98316 num_sets=683"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 67633324,
+      "real_time": 1.0393221805558986e+02,
+      "cpu_time": 1.0392865845245244e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.499 size=1572868 num_sets=43"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20972370,
+      "real_time": 9.0713724503110512e+01,
+      "cpu_time": 9.0710295402933312e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.248 size=194 num_sets=21621"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20972250,
+      "real_time": 9.2071287466210464e+01,
+      "cpu_time": 9.2066888340547308e+01,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=1.253 size=390 num_sets=10755"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20978320,
+      "real_time": 9.9476901513204595e+01,
+      "cpu_time": 9.9475742766823402e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.250 size=6152 num_sets=682"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21138370,
+      "real_time": 1.0329087015464900e+02,
+      "cpu_time": 1.0328911907587725e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.250 size=98318 num_sets=43"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 23593050,
+      "real_time": 1.0524895282540916e+02,
+      "cpu_time": 1.0524676101647933e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.249 size=1572870 num_sets=3"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20972160,
+      "real_time": 1.0689589150304299e+02,
+      "cpu_time": 1.0689561575918545e+02,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=1.495 size=192 num_sets=21846"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20973340,
+      "real_time": 1.0766059584162393e+02,
+      "cpu_time": 1.0765925432000505e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.498 size=388 num_sets=10811"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 21002250,
+      "real_time": 1.1510287867222560e+02,
+      "cpu_time": 1.1510115649513308e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.500 size=6150 num_sets=683"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21137940,
+      "real_time": 1.1436218705335121e+02,
+      "cpu_time": 1.1433565735354733e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.501 size=98316 num_sets=43"
+    },
+    {
+      "name": "BM<InsertHit_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 23593020,
+      "real_time": 1.1834665623093298e+02,
+      "cpu_time": 1.1834655847365420e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.499 size=1572868 num_sets=3"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 67108877,
+      "real_time": 8.0565892116155283e+01,
+      "cpu_time": 8.0566272178870634e+01,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=1.000 size=17 num_sets=3947581"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 67108868,
+      "real_time": 1.3214825423418188e+02,
+      "cpu_time": 1.3213854279288464e+02,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.000 size=257 num_sets=261124"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 67109419,
+      "real_time": 1.7960068248107029e+02,
+      "cpu_time": 1.7960118905216527e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.000 size=4349 num_sets=15431"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 67172386,
+      "real_time": 1.4349053051503316e+02,
+      "cpu_time": 1.4348968419850550e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=67307 num_sets=998"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67604672,
+      "real_time": 1.4433164112566928e+02,
+      "cpu_time": 1.4432630176801723e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=1056323 num_sets=64"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 67108895,
+      "real_time": 1.6968922955280647e+02,
+      "cpu_time": 1.6968866534011801e+02,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.000 size=35 num_sets=1917397"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 67109273,
+      "real_time": 2.2711884420928646e+02,
+      "cpu_time": 2.2711935788665070e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=539 num_sets=124507"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 67108986,
+      "real_time": 1.4944083847852096e+02,
+      "cpu_time": 1.4943934664725330e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=4347 num_sets=15438"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 67170390,
+      "real_time": 1.5120803256409758e+02,
+      "cpu_time": 1.5120876862557799e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=67305 num_sets=998"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 67604544,
+      "real_time": 1.7270639240084643e+02,
+      "cpu_time": 1.7270227603339774e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=1056321 num_sets=64"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971540,
+      "real_time": 1.1507952815952075e+02,
+      "cpu_time": 1.1507705604834882e+02,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=1.000 size=17 num_sets=246724"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20972485,
+      "real_time": 1.3114645508133441e+02,
+      "cpu_time": 1.3114265348146213e+02,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.000 size=257 num_sets=16321"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20983925,
+      "real_time": 1.4461428088037530e+02,
+      "cpu_time": 1.4460608279908823e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.000 size=4349 num_sets=965"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21201705,
+      "real_time": 1.4537802687022437e+02,
+      "cpu_time": 1.4537434050703723e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=67307 num_sets=63"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 21126460,
+      "real_time": 1.4904155749961865e+02,
+      "cpu_time": 1.4903642091482035e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=1056323 num_sets=4"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971650,
+      "real_time": 1.3729249008023044e+02,
+      "cpu_time": 1.3728802860052949e+02,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.000 size=35 num_sets=119838"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20972490,
+      "real_time": 1.5253262318826930e+02,
+      "cpu_time": 1.5252791080125158e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=539 num_sets=7782"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20974275,
+      "real_time": 1.6276645946512576e+02,
+      "cpu_time": 1.6272091512102048e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=4347 num_sets=965"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21201075,
+      "real_time": 1.6745711223709853e+02,
+      "cpu_time": 1.6743861374954804e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=67305 num_sets=63"
+    },
+    {
+      "name": "BM<InsertHit_Cold, std::unordered_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 21126420,
+      "real_time": 1.7561229805876195e+02,
+      "cpu_time": 1.7558790268298591e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.000 size=1056321 num_sets=4"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 67108881,
+      "real_time": 2.4477700771762976e+01,
+      "cpu_time": 2.4477224407899580e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=1.039 size=21 num_sets=3195661"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 67108902,
+      "real_time": 3.8481533929784590e+01,
+      "cpu_time": 3.8478987705680424e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=321 num_sets=209062"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 67110705,
+      "real_time": 5.5239029208683284e+01,
+      "cpu_time": 5.5239090097473884e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=5121 num_sets=13105"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 67175220,
+      "real_time": 4.3270727483663563e+01,
+      "cpu_time": 4.3270003611456708e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=81921 num_sets=820"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 68157492,
+      "real_time": 4.6295781090359469e+01,
+      "cpu_time": 4.6293235511074478e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.038 size=1310721 num_sets=52"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 67108874,
+      "real_time": 1.6351916493387762e+01,
+      "cpu_time": 1.6351898215429149e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.071 size=19 num_sets=3532046"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 67108987,
+      "real_time": 4.4287773988444904e+01,
+      "cpu_time": 4.4287280018099111e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.089 size=319 num_sets=210373"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 67110090,
+      "real_time": 4.8012996624772860e+01,
+      "cpu_time": 4.8008896024428751e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=5119 num_sets=13110"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 67173580,
+      "real_time": 7.1755933360540993e+01,
+      "cpu_time": 7.1755967569394130e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=81919 num_sets=820"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 68157388,
+      "real_time": 5.3098230150772672e+01,
+      "cpu_time": 5.3098445233842853e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.090 size=1310719 num_sets=52"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971625,
+      "real_time": 5.3360912485819519e+01,
+      "cpu_time": 5.3359431469922853e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=1.047 size=25 num_sets=167773"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20972875,
+      "real_time": 5.4013856061242421e+01,
+      "cpu_time": 5.4012648051345415e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=385 num_sets=10895"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20985175,
+      "real_time": 5.8560693110786424e+01,
+      "cpu_time": 5.8560873521435731e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=6145 num_sets=683"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21135575,
+      "real_time": 5.7789207473106522e+01,
+      "cpu_time": 5.7788326648310232e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=98305 num_sets=43"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 23592975,
+      "real_time": 5.7196872770104733e+01,
+      "cpu_time": 5.7194795738974918e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.046 size=1572865 num_sets=3"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971630,
+      "real_time": 5.2546383318421803e+01,
+      "cpu_time": 5.2546291442288897e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=1.088 size=23 num_sets=182362"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20973080,
+      "real_time": 5.4864620034588590e+01,
+      "cpu_time": 5.4863275923241673e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.108 size=383 num_sets=10952"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20978345,
+      "real_time": 5.8344537842212169e+01,
+      "cpu_time": 5.8344367251073059e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.109 size=6143 num_sets=683"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21135145,
+      "real_time": 5.8633105601602715e+01,
+      "cpu_time": 5.8631728052961421e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.109 size=98303 num_sets=43"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14ValueSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 23592945,
+      "real_time": 6.0036025965828813e+01,
+      "cpu_time": 6.0036287924197403e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.109 size=1572863 num_sets=3"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 67108875,
+      "real_time": 6.6002552596051785e+01,
+      "cpu_time": 6.6002375840748655e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=1.047 size=25 num_sets=2684355"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 67108965,
+      "real_time": 1.3685140852133264e+02,
+      "cpu_time": 1.3684595487354036e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=385 num_sets=174309"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 67109545,
+      "real_time": 8.5728011829919609e+01,
+      "cpu_time": 8.5724572935194431e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=6145 num_sets=10921"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 67142315,
+      "real_time": 1.3313932024653579e+02,
+      "cpu_time": 1.3313933648251543e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=98305 num_sets=683"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67633195,
+      "real_time": 7.4309649810658826e+01,
+      "cpu_time": 7.4309160878767983e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.046 size=1572865 num_sets=43"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 67108871,
+      "real_time": 5.1574334086165230e+01,
+      "cpu_time": 5.1573644071588866e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=1.088 size=23 num_sets=2917777"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 67108877,
+      "real_time": 9.7638173728091800e+01,
+      "cpu_time": 9.7638182635657955e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.107 size=383 num_sets=175219"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 67112275,
+      "real_time": 8.8943201284025278e+01,
+      "cpu_time": 8.8942689291940695e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.109 size=6143 num_sets=10925"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 67140949,
+      "real_time": 9.8288818352160703e+01,
+      "cpu_time": 9.8289271559149526e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.109 size=98303 num_sets=683"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 67633109,
+      "real_time": 9.9995674746738061e+01,
+      "cpu_time": 9.9995716373168875e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.109 size=1572863 num_sets=43"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971625,
+      "real_time": 9.1963732972947454e+01,
+      "cpu_time": 9.1963079828087416e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=1.047 size=25 num_sets=167773"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20972875,
+      "real_time": 6.0310256228731127e+01,
+      "cpu_time": 6.0307367540210052e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=385 num_sets=10895"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20985175,
+      "real_time": 7.0612052471745400e+01,
+      "cpu_time": 7.0611364832567958e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=6145 num_sets=683"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21135575,
+      "real_time": 7.0819705857085097e+01,
+      "cpu_time": 7.0819077172023214e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.047 size=98305 num_sets=43"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 23592975,
+      "real_time": 7.0420573739593124e+01,
+      "cpu_time": 7.0420192832839533e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.046 size=1572865 num_sets=3"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971630,
+      "real_time": 6.6957706024968914e+01,
+      "cpu_time": 6.6956842934939246e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=1.087 size=23 num_sets=182362"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20973080,
+      "real_time": 6.8895249234102124e+01,
+      "cpu_time": 6.8893878343088772e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.107 size=383 num_sets=10952"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20978345,
+      "real_time": 7.7420710852823305e+01,
+      "cpu_time": 7.7418706480423694e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.109 size=6143 num_sets=683"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21135145,
+      "real_time": 8.1247124713727530e+01,
+      "cpu_time": 8.1247325627517654e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.109 size=98303 num_sets=43"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14NodeSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 23592945,
+      "real_time": 7.4388781085240026e+01,
+      "cpu_time": 7.4388899774902981e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.109 size=1572863 num_sets=3"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 67108881,
+      "real_time": 3.7873559575612667e+01,
+      "cpu_time": 3.7873709278504109e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=1.039 size=21 num_sets=3195661"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 67108902,
+      "real_time": 7.6525988401301063e+01,
+      "cpu_time": 7.6525795087512648e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=321 num_sets=209062"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 67110705,
+      "real_time": 7.7845683314320510e+01,
+      "cpu_time": 7.7845455087973946e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=5121 num_sets=13105"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 67175220,
+      "real_time": 8.3962425668961600e+01,
+      "cpu_time": 8.3962590863121591e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=81921 num_sets=820"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 68157492,
+      "real_time": 8.4177123008846507e+01,
+      "cpu_time": 8.4177473813153895e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=1310721 num_sets=52"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 67108874,
+      "real_time": 3.0318715461209340e+01,
+      "cpu_time": 3.0317751956320318e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.071 size=19 num_sets=3532046"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 67108987,
+      "real_time": 7.9123250814785038e+01,
+      "cpu_time": 7.9122154295063396e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.089 size=319 num_sets=210373"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 67110090,
+      "real_time": 8.4371472097213172e+01,
+      "cpu_time": 8.4371702824420524e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=5119 num_sets=13110"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 67173580,
+      "real_time": 9.4246054462936030e+01,
+      "cpu_time": 9.4245903047003182e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=81919 num_sets=820"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 68157388,
+      "real_time": 9.5394463942619623e+01,
+      "cpu_time": 9.5391901080483834e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.090 size=1310719 num_sets=52"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971545,
+      "real_time": 7.0264589251380656e+01,
+      "cpu_time": 7.0264642781413869e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=1.039 size=21 num_sets=199729"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20972535,
+      "real_time": 6.8911511205391193e+01,
+      "cpu_time": 6.8906102195106328e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=321 num_sets=13067"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20996100,
+      "real_time": 7.8480729272742209e+01,
+      "cpu_time": 7.8475346230946258e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=5121 num_sets=820"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21299460,
+      "real_time": 7.7376458027096433e+01,
+      "cpu_time": 7.7373145281592215e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=81921 num_sets=52"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 20971536,
+      "real_time": 9.2710249399720865e+01,
+      "cpu_time": 9.2706912264322440e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.039 size=1310721 num_sets=4"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971535,
+      "real_time": 6.7965046628262328e+01,
+      "cpu_time": 6.7964993835720747e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=1.071 size=19 num_sets=220753"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20972655,
+      "real_time": 6.4889992346680728e+01,
+      "cpu_time": 6.4888423902449162e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.089 size=319 num_sets=13149"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20987900,
+      "real_time": 8.0365517442298739e+01,
+      "cpu_time": 8.0363497110271240e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=5119 num_sets=820"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21298940,
+      "real_time": 8.7702564480047599e+01,
+      "cpu_time": 8.7700950986296419e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.091 size=81919 num_sets=52"
+    },
+    {
+      "name": "BM<InsertHit_Cold, folly::F14VectorSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 20971504,
+      "real_time": 8.8545754604240344e+01,
+      "cpu_time": 8.8541523774342565e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=1.090 size=1310719 num_sets=4"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 67108877,
+      "real_time": 2.5386571478851117e+01,
+      "cpu_time": 2.5385018363524335e+01,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=2.315 size=17 num_sets=3947581"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 67108868,
+      "real_time": 3.5790866801935181e+01,
+      "cpu_time": 3.5789653835322923e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.323 size=257 num_sets=261124"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 67112957,
+      "real_time": 4.8054236285001345e+01,
+      "cpu_time": 4.8053594911631635e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.324 size=4097 num_sets=16381"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 67109888,
+      "real_time": 5.1891188693679204e+01,
+      "cpu_time": 5.1889027768906004e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.324 size=65537 num_sets=1024"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67108928,
+      "real_time": 3.7277217733848502e+01,
+      "cpu_time": 3.7274894064766286e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.322 size=1048577 num_sets=64"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 67108893,
+      "real_time": 3.0475118582147896e+01,
+      "cpu_time": 3.0474459383500339e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=2.751 size=31 num_sets=2164803"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 67109119,
+      "real_time": 3.7789840881321638e+01,
+      "cpu_time": 3.7789147746079756e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.861 size=511 num_sets=131329"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 67117054,
+      "real_time": 5.3207519279025149e+01,
+      "cpu_time": 5.3201084690045278e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.868 size=8191 num_sets=8194"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 67239423,
+      "real_time": 4.2235295359130241e+01,
+      "cpu_time": 4.2234155667869743e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.869 size=131071 num_sets=513"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 69205983,
+      "real_time": 4.8163513777918062e+01,
+      "cpu_time": 4.8163084772594509e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.866 size=2097151 num_sets=33"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971540,
+      "real_time": 4.9317587387814896e+01,
+      "cpu_time": 4.9317382223739571e+01,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=2.316 size=17 num_sets=246724"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20972485,
+      "real_time": 4.2085237735805755e+01,
+      "cpu_time": 4.2084764442577260e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.324 size=257 num_sets=16321"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20976640,
+      "real_time": 4.4904171434850092e+01,
+      "cpu_time": 4.4903853000275689e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.324 size=4097 num_sets=1024"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971840,
+      "real_time": 4.2903234501107072e+01,
+      "cpu_time": 4.2903493589510632e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.324 size=65537 num_sets=64"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 20971540,
+      "real_time": 4.3252627753038361e+01,
+      "cpu_time": 4.3252003858557124e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=2.323 size=1048577 num_sets=4"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971655,
+      "real_time": 5.4406054841854079e+01,
+      "cpu_time": 5.4405975541735991e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=2.751 size=31 num_sets=135301"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20973995,
+      "real_time": 5.4875503596497467e+01,
+      "cpu_time": 5.4874961255579969e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.861 size=511 num_sets=8209"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 21009915,
+      "real_time": 5.7324625969581980e+01,
+      "cpu_time": 5.7325686419976677e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.869 size=8191 num_sets=513"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21626715,
+      "real_time": 5.5507833219686503e+01,
+      "cpu_time": 5.5508065371951801e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.868 size=131071 num_sets=33"
+    },
+    {
+      "name": "BM<InsertHit_Cold, google::dense_hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 25165812,
+      "real_time": 5.7683260510482754e+01,
+      "cpu_time": 5.7682331211879223e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.867 size=2097151 num_sets=3"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 6.9521070145128760e+01,
+      "cpu_time": 6.9521309757234960e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.993 size=194 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 7.1102715537563199e+01,
+      "cpu_time": 7.1103153276427449e+01,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=2.010 size=390 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 8.3668942352232989e+01,
+      "cpu_time": 8.3668334722487856e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.001 size=6152 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 1.0542967174842488e+02,
+      "cpu_time": 1.0543011889460782e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.000 size=98318 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 23593050,
+      "real_time": 3.2032501501974406e+02,
+      "cpu_time": 3.2032375165567856e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.997 size=1572870 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 6.9686961978732143e+01,
+      "cpu_time": 6.9687071800215648e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.994 size=194 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 6.9832913140999153e+01,
+      "cpu_time": 6.9833117437387983e+01,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=2.011 size=390 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 9.1208187313895905e+01,
+      "cpu_time": 9.1207858085627990e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.003 size=6152 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 1.1087494158346090e+02,
+      "cpu_time": 1.1087509598733773e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.999 size=98318 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 23593050,
+      "real_time": 3.7498706506209072e+02,
+      "cpu_time": 3.7498726510559118e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.999 size=1572870 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 9.0633648142102174e+01,
+      "cpu_time": 9.0633892679218420e+01,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=1.000 size=17 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 9.2547020358324517e+01,
+      "cpu_time": 9.2546665382423413e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.000 size=257 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 1.0910915761996876e+02,
+      "cpu_time": 1.0910922188761378e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.000 size=4349 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 1.7918554249263252e+02,
+      "cpu_time": 1.7918602299689738e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=67307 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 22182783,
+      "real_time": 4.0114427434055671e+02,
+      "cpu_time": 4.0114288265814952e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=1056323 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 9.4163658559409669e+01,
+      "cpu_time": 9.4163674306839070e+01,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=1.000 size=17 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 9.5853670245560352e+01,
+      "cpu_time": 9.5850876903526981e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.000 size=257 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 1.4074887531023705e+02,
+      "cpu_time": 1.4074531497951756e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.000 size=4349 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 1.9026259678867063e+02,
+      "cpu_time": 1.9026000661853499e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=67307 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 22182783,
+      "real_time": 5.7641877913958956e+02,
+      "cpu_time": 5.7641751997484562e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=1056323 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, std::unordered_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 1.8907348930952139e+01,
+      "cpu_time": 1.8907083892830482e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=1.109 size=21 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 1.5485943549720105e+01,
+      "cpu_time": 1.5486008167258856e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.108 size=321 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 1.6059107110777404e+01,
+      "cpu_time": 1.6058087062842397e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.108 size=5121 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 2.4030873646552209e+01,
+      "cpu_time": 2.4030558729189188e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.108 size=81921 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 23592978,
+      "real_time": 5.2772813794601340e+01,
+      "cpu_time": 5.2772792268973845e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.107 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 1.9823175989586161e+01,
+      "cpu_time": 1.9823275041602749e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=1.133 size=25 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 1.7516424577479484e+01,
+      "cpu_time": 1.7515992021535293e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.130 size=385 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 2.5707015538500855e+01,
+      "cpu_time": 2.5707001876816225e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.130 size=6145 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 5.8842636008193949e+01,
+      "cpu_time": 5.8842509222025583e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.130 size=98305 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 23592975,
+      "real_time": 2.4572578837119832e+02,
+      "cpu_time": 2.4572237062090906e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.128 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14ValueSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 4.1526516270096181e+01,
+      "cpu_time": 4.1525977659230207e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=1.132 size=25 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 4.1491216506983619e+01,
+      "cpu_time": 4.1491162347832500e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.129 size=385 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 5.5990597047639312e+01,
+      "cpu_time": 5.5990848875061076e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.129 size=6145 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 8.7967782747000456e+01,
+      "cpu_time": 8.7967989540090045e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.130 size=98305 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 23592975,
+      "real_time": 2.6237840345228602e+02,
+      "cpu_time": 2.6237917829351966e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.129 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 4.2127896904275985e+01,
+      "cpu_time": 4.2128149223318381e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=1.131 size=25 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 4.2383214804431191e+01,
+      "cpu_time": 4.2383334064501760e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.130 size=385 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 6.5199662913073553e+01,
+      "cpu_time": 6.5199885225259578e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.131 size=6145 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 1.0220854846920702e+02,
+      "cpu_time": 1.0220806655881869e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.129 size=98305 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 23592975,
+      "real_time": 4.2651603069045245e+02,
+      "cpu_time": 4.2649896390768441e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.129 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14NodeSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 2.4210623905673856e+01,
+      "cpu_time": 2.4208596134146777e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=1.109 size=21 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 2.1479502265719930e+01,
+      "cpu_time": 2.1479615592949475e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.108 size=321 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 2.9598970741062658e+01,
+      "cpu_time": 2.9598602151875706e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.108 size=5121 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 3.8542532365681836e+01,
+      "cpu_time": 3.8542585372933203e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.109 size=81921 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 23592978,
+      "real_time": 9.0275384884652823e+01,
+      "cpu_time": 9.0274999790174192e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.107 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 2.5382632884429768e+01,
+      "cpu_time": 2.5382779932038233e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=1.109 size=21 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 2.4493374439771287e+01,
+      "cpu_time": 2.4493542766582109e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.108 size=321 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 3.5656989894050639e+01,
+      "cpu_time": 3.5656622552867127e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.108 size=5121 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 4.8603283175907563e+01,
+      "cpu_time": 4.8602586603160162e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.107 size=81921 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 23592978,
+      "real_time": 1.8699055325250751e+02,
+      "cpu_time": 1.8698701130479628e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.107 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, folly::F14VectorSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 5.0360654313408304e+01,
+      "cpu_time": 5.0360808324847326e+01,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=14.094 size=17 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 4.5756507915939437e+01,
+      "cpu_time": 4.5756428432471019e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=14.359 size=257 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 4.5551530547527364e+01,
+      "cpu_time": 4.5551686859122974e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=14.376 size=4097 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 5.3668122745875735e+01,
+      "cpu_time": 5.3668482065220850e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=14.401 size=65537 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 22020117,
+      "real_time": 6.0835750246515929e+01,
+      "cpu_time": 6.0835976257557057e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=14.835 size=1048577 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 7.0557234721491113e+01,
+      "cpu_time": 7.0554711341852197e+01,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=14.093 size=17 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 6.8321946855576243e+01,
+      "cpu_time": 6.8322048139574790e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=14.355 size=257 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 9.0867695234919665e+01,
+      "cpu_time": 9.0866293430292430e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=14.379 size=4097 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 1.2763258609993500e+02,
+      "cpu_time": 1.2763156385419208e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=14.394 size=65537 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 22020117,
+      "real_time": 3.0614172043723715e+02,
+      "cpu_time": 3.0612891952390555e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=14.832 size=1048577 num_sets=1"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Hot, google::dense_hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 100663302,
+      "real_time": 4.8755098383513428e+02,
+      "cpu_time": 4.8754988694887368e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.992 size=194 num_sets=172961"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 100664460,
+      "real_time": 3.8985730235298945e+02,
+      "cpu_time": 3.8984901256113602e+02,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=2.012 size=390 num_sets=86038"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 100677480,
+      "real_time": 6.2433547997564312e+02,
+      "cpu_time": 6.2433432875951939e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.001 size=6152 num_sets=5455"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 100874268,
+      "real_time": 4.5123789810778669e+02,
+      "cpu_time": 4.5123626545672124e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.000 size=98318 num_sets=342"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 103809420,
+      "real_time": 5.0684514159242804e+02,
+      "cpu_time": 5.0684458053998969e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.997 size=1572870 num_sets=22"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 25168008,
+      "real_time": 3.2419500690676540e+02,
+      "cpu_time": 3.2419345130532486e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.992 size=194 num_sets=10811"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 25169040,
+      "real_time": 3.8307070633979606e+02,
+      "cpu_time": 3.8306704629971574e+02,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=2.012 size=390 num_sets=5378"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 25173984,
+      "real_time": 3.9285205307681730e+02,
+      "cpu_time": 3.9283985196782589e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.002 size=6152 num_sets=341"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 25955952,
+      "real_time": 3.9599949749973331e+02,
+      "cpu_time": 3.9598600521373709e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.000 size=98318 num_sets=22"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 28311660,
+      "real_time": 4.2384399257150335e+02,
+      "cpu_time": 4.2382845516651884e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.996 size=1572870 num_sets=2"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 100663341,
+      "real_time": 2.4780268676448947e+02,
+      "cpu_time": 2.4779731259863198e+02,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=1.000 size=17 num_sets=1973791"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 100663302,
+      "real_time": 1.0197131443544513e+03,
+      "cpu_time": 1.0197110245698065e+03,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.000 size=257 num_sets=130562"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 100670652,
+      "real_time": 9.4269834402631409e+02,
+      "cpu_time": 9.4269741175411684e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.000 size=4349 num_sets=7716"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 100758579,
+      "real_time": 7.7119322084663690e+02,
+      "cpu_time": 7.7118968063255056e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=67307 num_sets=499"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 101407008,
+      "real_time": 9.1408421466307789e+02,
+      "cpu_time": 9.1408259540602967e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=1056323 num_sets=32"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 25165848,
+      "real_time": 4.7924165147563997e+02,
+      "cpu_time": 4.7922430696554142e+02,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=1.000 size=17 num_sets=123362"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 25168524,
+      "real_time": 5.9414375212731318e+02,
+      "cpu_time": 5.9413356484472001e+02,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.000 size=257 num_sets=8161"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 25206804,
+      "real_time": 6.7114143084001228e+02,
+      "cpu_time": 6.7112631656912470e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.000 size=4349 num_sets=483"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 25845888,
+      "real_time": 8.0008662716789229e+02,
+      "cpu_time": 8.0008226000979118e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=67307 num_sets=32"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 25351752,
+      "real_time": 8.8754147911358098e+02,
+      "cpu_time": 8.8753165832482500e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=1.000 size=1056323 num_sets=2"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, std::unordered_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 100663353,
+      "real_time": 4.0075530257698844e+01,
+      "cpu_time": 4.0075310406161869e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=1.110 size=21 num_sets=1597831"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 100663353,
+      "real_time": 1.8292428020865663e+02,
+      "cpu_time": 1.8292447980548346e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.109 size=321 num_sets=104531"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 100673739,
+      "real_time": 3.2667002729648482e+02,
+      "cpu_time": 3.2666668489386007e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.109 size=5121 num_sets=6553"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 100762830,
+      "real_time": 2.7995987161332522e+02,
+      "cpu_time": 2.7995937659749433e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.109 size=81921 num_sets=410"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 102236238,
+      "real_time": 3.8481636181325126e+02,
+      "cpu_time": 3.8481042751201647e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.108 size=1310721 num_sets=26"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 25166100,
+      "real_time": 1.8192819003436674e+02,
+      "cpu_time": 1.8192417883584858e+02,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=1.132 size=25 num_sets=83887"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 25169760,
+      "real_time": 2.4369023749527207e+02,
+      "cpu_time": 2.4368620618552461e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.130 size=385 num_sets=5448"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 25219080,
+      "real_time": 3.8017188615921640e+02,
+      "cpu_time": 3.8017111805823311e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.131 size=6145 num_sets=342"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 25952520,
+      "real_time": 2.7456529744080450e+02,
+      "cpu_time": 2.7455987187371312e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.130 size=98305 num_sets=22"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 28311570,
+      "real_time": 2.9279697168905057e+02,
+      "cpu_time": 2.9279128550625461e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.129 size=1572865 num_sets=2"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14ValueSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 100663350,
+      "real_time": 3.4765409220224024e+02,
+      "cpu_time": 3.4765433210796243e+02,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=1.133 size=25 num_sets=1342178"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 100664025,
+      "real_time": 3.7527248165027328e+02,
+      "cpu_time": 3.7526459664214457e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.132 size=385 num_sets=87155"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 100673535,
+      "real_time": 4.0775290902234138e+02,
+      "cpu_time": 4.0775333332638155e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.132 size=6145 num_sets=5461"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 100860930,
+      "real_time": 5.4911387117999027e+02,
+      "cpu_time": 5.4910856670665589e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.132 size=98305 num_sets=342"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 103809090,
+      "real_time": 5.8725378929273336e+02,
+      "cpu_time": 5.8725439801081802e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.130 size=1572865 num_sets=22"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 25166100,
+      "real_time": 2.7880819898815417e+02,
+      "cpu_time": 2.7879131196333981e+02,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=1.132 size=25 num_sets=83887"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 25169760,
+      "real_time": 2.8966318660669907e+02,
+      "cpu_time": 2.8966291963052942e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.131 size=385 num_sets=5448"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 25219080,
+      "real_time": 3.2228068454327195e+02,
+      "cpu_time": 3.2227849965184794e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.131 size=6145 num_sets=342"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 25952520,
+      "real_time": 3.3119745897719412e+02,
+      "cpu_time": 3.3119631303627034e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.130 size=98305 num_sets=22"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 28311570,
+      "real_time": 3.6905588968805591e+02,
+      "cpu_time": 3.6905767239333176e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.128 size=1572865 num_sets=2"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14NodeSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 100663353,
+      "real_time": 6.1492261472336949e+01,
+      "cpu_time": 6.1492562402526467e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=1.110 size=21 num_sets=1597831"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 100663353,
+      "real_time": 4.3730918607840601e+02,
+      "cpu_time": 4.3731099341584115e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.109 size=321 num_sets=104531"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 100673739,
+      "real_time": 4.9297844146131519e+02,
+      "cpu_time": 4.9297879379447204e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.109 size=5121 num_sets=6553"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 100762830,
+      "real_time": 5.3708351212815467e+02,
+      "cpu_time": 5.3707673039750887e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.109 size=81921 num_sets=410"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 102236238,
+      "real_time": 3.7954504414924332e+02,
+      "cpu_time": 3.7954525238888448e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.108 size=1310721 num_sets=26"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 25165980,
+      "real_time": 2.3963217857127955e+02,
+      "cpu_time": 2.3962882391229564e+02,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=1.109 size=21 num_sets=99865"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 25168968,
+      "real_time": 3.3203366937505018e+02,
+      "cpu_time": 3.3203482812643472e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.108 size=321 num_sets=6534"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 25195320,
+      "real_time": 3.3515895122497113e+02,
+      "cpu_time": 3.3515905001404525e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.109 size=5121 num_sets=410"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 25559352,
+      "real_time": 2.4503041293478003e+02,
+      "cpu_time": 2.4502910112898823e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.108 size=81921 num_sets=26"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 23592978,
+      "real_time": 2.4101343624447858e+02,
+      "cpu_time": 2.4101091846057400e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.106 size=1310721 num_sets=2"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, folly::F14VectorSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 100663341,
+      "real_time": 9.3486684124332001e+01,
+      "cpu_time": 9.3487048656566017e+01,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=12.638 size=17 num_sets=1973791"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 100663302,
+      "real_time": 1.0977328968774390e+02,
+      "cpu_time": 1.0977237297461423e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=13.120 size=257 num_sets=130562"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 100675581,
+      "real_time": 1.0747794235379634e+02,
+      "cpu_time": 1.0747796211873893e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=13.156 size=4097 num_sets=8191"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 100664832,
+      "real_time": 1.1496690256121190e+02,
+      "cpu_time": 1.1496709358238714e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=13.157 size=65537 num_sets=512"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 100663392,
+      "real_time": 1.1541443600059121e+02,
+      "cpu_time": 1.1541189220009387e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=13.150 size=1048577 num_sets=32"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 25165848,
+      "real_time": 2.3216146047258411e+02,
+      "cpu_time": 2.3215921176190244e+02,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=13.818 size=17 num_sets=123362"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 25168524,
+      "real_time": 2.3419067815074422e+02,
+      "cpu_time": 2.3419026956048097e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=13.987 size=257 num_sets=8161"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 25171968,
+      "real_time": 2.2846203344052631e+02,
+      "cpu_time": 2.2845764963627460e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=13.854 size=4097 num_sets=512"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 25166208,
+      "real_time": 2.3696989930747850e+02,
+      "cpu_time": 2.3696707279062196e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=13.860 size=65537 num_sets=32"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 25165848,
+      "real_time": 3.0887864859377760e+02,
+      "cpu_time": 3.0887350297116268e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=13.846 size=1048577 num_sets=2"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<EraseInsert_Cold, google::dense_hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 0,
+      "real_time": 0.0000000000000000e+00,
+      "cpu_time": 0.0000000000000000e+00,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33548032,
+      "real_time": 4.2413614180150503e+01,
+      "cpu_time": 4.2413767370923942e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.253 size=194 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33546240,
+      "real_time": 4.6933462424829180e+01,
+      "cpu_time": 4.6933710663241776e+01,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=0.238 size=390 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33073152,
+      "real_time": 5.4493688470926500e+01,
+      "cpu_time": 5.4493191456314648e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.251 size=6152 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 25169408,
+      "real_time": 6.2744985912685152e+01,
+      "cpu_time": 6.2745439026628972e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.252 size=98318 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 100663680,
+      "real_time": 1.9547122835099651e+02,
+      "cpu_time": 1.9547167411324588e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.249 size=1572870 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33546240,
+      "real_time": 4.4121115578745602e+01,
+      "cpu_time": 4.4121116613950626e+01,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=0.495 size=192 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33523200,
+      "real_time": 4.5860841238758134e+01,
+      "cpu_time": 4.5861131276252820e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.441 size=388 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33062400,
+      "real_time": 5.4549975331513586e+01,
+      "cpu_time": 5.4548785296906836e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.487 size=6150 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 25168896,
+      "real_time": 9.9043601957818240e+01,
+      "cpu_time": 9.9044308737277817e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.501 size=98316 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 100663552,
+      "real_time": 2.5768880199155745e+02,
+      "cpu_time": 2.5768573951175404e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.499 size=1572868 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33548032,
+      "real_time": 4.1919657236850398e+01,
+      "cpu_time": 4.1919382424591419e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.273 size=194 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33546240,
+      "real_time": 4.4157994644982473e+01,
+      "cpu_time": 4.4157828030790213e+01,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=0.267 size=390 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33073152,
+      "real_time": 5.9068560472482702e+01,
+      "cpu_time": 5.9065283254546017e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.240 size=6152 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 25169408,
+      "real_time": 6.9497960262456303e+01,
+      "cpu_time": 6.9495608160501604e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.250 size=98318 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 100663680,
+      "real_time": 3.7818270445702177e+02,
+      "cpu_time": 3.7810449396445495e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.249 size=1572870 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33546240,
+      "real_time": 4.3720833079318567e+01,
+      "cpu_time": 4.3720896738368111e+01,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=0.505 size=192 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33523200,
+      "real_time": 4.5514384973772884e+01,
+      "cpu_time": 4.5513885726912925e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.552 size=388 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33062400,
+      "real_time": 6.3711110296242005e+01,
+      "cpu_time": 6.3709996370500235e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.511 size=6150 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 25168896,
+      "real_time": 8.0429758691502542e+01,
+      "cpu_time": 8.0429284105276096e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.501 size=98316 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 100663552,
+      "real_time": 2.9612041895442860e+02,
+      "cpu_time": 2.9612039641716632e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.499 size=1572868 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33553920,
+      "real_time": 8.8163946050432330e+01,
+      "cpu_time": 8.8163697386170796e+01,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=0.000 size=17 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33553920,
+      "real_time": 8.2654235446135672e+01,
+      "cpu_time": 8.2652089830341424e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=0.000 size=257 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33400320,
+      "real_time": 9.0273703191712912e+01,
+      "cpu_time": 9.0273494625200186e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=4349 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 25845888,
+      "real_time": 1.3683352262656481e+02,
+      "cpu_time": 1.3683335329784160e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=67307 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67604672,
+      "real_time": 2.5890596707714610e+02,
+      "cpu_time": 2.5890400539180467e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=1056323 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33550720,
+      "real_time": 5.3733533826289197e+01,
+      "cpu_time": 5.3732860099569720e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=35 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33530112,
+      "real_time": 5.7404602555181526e+01,
+      "cpu_time": 5.7405007892614321e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=539 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33384960,
+      "real_time": 6.2726014411922030e+01,
+      "cpu_time": 6.2726143119538378e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=4347 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 25845120,
+      "real_time": 9.9544446712717118e+01,
+      "cpu_time": 9.9544479576801038e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=67305 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 67604544,
+      "real_time": 2.0042229745512353e+02,
+      "cpu_time": 2.0042102313418962e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1056321 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33553920,
+      "real_time": 8.6604373318803226e+01,
+      "cpu_time": 8.6604299855260138e+01,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=0.000 size=17 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33553920,
+      "real_time": 8.2144910641463071e+01,
+      "cpu_time": 8.2143817920520391e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=0.000 size=257 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33400320,
+      "real_time": 1.1041643235193155e+02,
+      "cpu_time": 1.1041438752683693e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=4349 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 25845888,
+      "real_time": 1.5786222282914861e+02,
+      "cpu_time": 1.5786017214808001e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=67307 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67604672,
+      "real_time": 6.7193286992296396e+02,
+      "cpu_time": 6.7193174595981486e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=1056323 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33550720,
+      "real_time": 5.4852513733672033e+01,
+      "cpu_time": 5.4852501526048229e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=35 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33530112,
+      "real_time": 6.1555823769315971e+01,
+      "cpu_time": 6.1555819407933193e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=539 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33384960,
+      "real_time": 7.7075230756261931e+01,
+      "cpu_time": 7.7074867635006854e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=4347 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 25845120,
+      "real_time": 1.0805137030564637e+02,
+      "cpu_time": 1.0805051831833198e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=67305 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, std::unordered_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 67604544,
+      "real_time": 3.1387931778591866e+02,
+      "cpu_time": 3.1387662363346874e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1056321 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33554304,
+      "real_time": 8.9290764560801978e+00,
+      "cpu_time": 8.9291264095305998e+00,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.048 size=21 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33527808,
+      "real_time": 8.8514684361045735e+00,
+      "cpu_time": 8.8515423376380387e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.040 size=321 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33429888,
+      "real_time": 9.7982661855573117e+00,
+      "cpu_time": 9.7983267248616102e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.042 size=5121 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 31457664,
+      "real_time": 1.4936509789755149e+01,
+      "cpu_time": 1.4936311799883944e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.038 size=81921 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 83886144,
+      "real_time": 2.9995118064354088e+01,
+      "cpu_time": 2.9994729689803783e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33554304,
+      "real_time": 1.0465744670923174e+01,
+      "cpu_time": 1.0465851683305544e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.105 size=19 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33523072,
+      "real_time": 9.2859296049600939e+00,
+      "cpu_time": 9.2860186858720901e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.068 size=319 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33416832,
+      "real_time": 9.5374189614514471e+00,
+      "cpu_time": 9.5373801741665147e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=5119 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 31456896,
+      "real_time": 1.5554019618488486e+01,
+      "cpu_time": 1.5554114716207289e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.085 size=81919 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 83886016,
+      "real_time": 2.2070494550528306e+01,
+      "cpu_time": 2.2070480412369403e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=1310719 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33552000,
+      "real_time": 9.4101365884827270e+00,
+      "cpu_time": 9.4102021638042999e+00,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.000 size=25 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33510400,
+      "real_time": 9.6712193136637765e+00,
+      "cpu_time": 9.6711911227314626e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.042 size=385 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33035520,
+      "real_time": 1.9213918326155902e+01,
+      "cpu_time": 1.9214050240456206e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=6145 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 25166080,
+      "real_time": 2.9634010736603113e+01,
+      "cpu_time": 2.9633458766724374e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.048 size=98305 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 100663360,
+      "real_time": 1.7522147280228270e+02,
+      "cpu_time": 1.7521842426082438e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.046 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33552768,
+      "real_time": 1.0648494134584375e+01,
+      "cpu_time": 1.0648566997505288e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.087 size=23 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33532416,
+      "real_time": 1.0468622885525328e+01,
+      "cpu_time": 1.0468601427363625e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.097 size=383 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33024768,
+      "real_time": 1.9157422963653797e+01,
+      "cpu_time": 1.9157583635414269e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.107 size=6143 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 25165568,
+      "real_time": 2.2965855913526131e+01,
+      "cpu_time": 2.2965704489563713e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.102 size=98303 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14ValueSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 100663232,
+      "real_time": 1.3321575134225571e+02,
+      "cpu_time": 1.3321477413917557e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.104 size=1572863 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33552000,
+      "real_time": 3.5936584004232529e+01,
+      "cpu_time": 3.5936719957073841e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.080 size=25 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33510400,
+      "real_time": 4.8276596198198540e+01,
+      "cpu_time": 4.8276850112219321e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.031 size=385 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33035520,
+      "real_time": 5.9684068270556210e+01,
+      "cpu_time": 5.9684399155818795e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.044 size=6145 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 25166080,
+      "real_time": 9.2220157240870577e+01,
+      "cpu_time": 9.2220518054479030e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.048 size=98305 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 100663360,
+      "real_time": 2.8743140215970323e+02,
+      "cpu_time": 2.8743176009622806e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.046 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33552768,
+      "real_time": 3.6190276259063623e+01,
+      "cpu_time": 3.6190379166337195e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.093 size=23 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33532416,
+      "real_time": 4.7832869918504436e+01,
+      "cpu_time": 4.7833131707551033e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.090 size=383 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33024768,
+      "real_time": 5.7724211056716690e+01,
+      "cpu_time": 5.7724013594872858e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.113 size=6143 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 25165568,
+      "real_time": 9.5609253583521408e+01,
+      "cpu_time": 9.5609160659511048e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.105 size=98303 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 100663232,
+      "real_time": 2.6386193219683230e+02,
+      "cpu_time": 2.6386109564811221e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.103 size=1572863 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33552000,
+      "real_time": 3.6042441228030690e+01,
+      "cpu_time": 3.6041417918464752e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.040 size=25 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33510400,
+      "real_time": 4.9686799291165570e+01,
+      "cpu_time": 4.9687053959371291e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.057 size=385 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33035520,
+      "real_time": 7.5166237049892800e+01,
+      "cpu_time": 7.5164875806386092e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.046 size=6145 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 25166080,
+      "real_time": 1.0763319768835791e+02,
+      "cpu_time": 1.0763311266594388e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.046 size=98305 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 100663360,
+      "real_time": 5.9541011213756440e+02,
+      "cpu_time": 5.9540187769413183e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.046 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33552768,
+      "real_time": 3.6225471186119712e+01,
+      "cpu_time": 3.6225044771271101e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.000 size=23 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33532416,
+      "real_time": 4.8815726443471959e+01,
+      "cpu_time": 4.8815729024726501e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.119 size=383 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33024768,
+      "real_time": 7.4747763722842748e+01,
+      "cpu_time": 7.4746782778313602e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.104 size=6143 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 25165568,
+      "real_time": 1.0790526386391586e+02,
+      "cpu_time": 1.0790511920891331e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.105 size=98303 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14NodeSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 100663232,
+      "real_time": 4.8798579397813342e+02,
+      "cpu_time": 4.8797737911892739e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.103 size=1572863 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33554304,
+      "real_time": 9.1810927149653239e+00,
+      "cpu_time": 9.1806399858644809e+00,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.048 size=21 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33527808,
+      "real_time": 8.6837965239820836e+00,
+      "cpu_time": 8.6838585749443915e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.028 size=321 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33429888,
+      "real_time": 9.9702519258336242e+00,
+      "cpu_time": 9.9703212885447705e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.038 size=5121 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 31457664,
+      "real_time": 1.5246764961725374e+01,
+      "cpu_time": 1.5246597967341403e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=81921 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 83886144,
+      "real_time": 3.2680077957560265e+01,
+      "cpu_time": 3.2679939764541217e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33554304,
+      "real_time": 9.7407183084522000e+00,
+      "cpu_time": 9.7402724848781759e+00,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.105 size=19 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33523072,
+      "real_time": 9.3468445214094249e+00,
+      "cpu_time": 9.3469077356455212e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.078 size=319 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33416832,
+      "real_time": 9.7177481316969097e+00,
+      "cpu_time": 9.7178613161422227e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.084 size=5119 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 31456896,
+      "real_time": 1.5971422148867873e+01,
+      "cpu_time": 1.5971312427020353e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=81919 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 83886016,
+      "real_time": 2.4542244398186785e+01,
+      "cpu_time": 2.4542008181664940e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.085 size=1310719 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33554304,
+      "real_time": 1.0443028533005734e+01,
+      "cpu_time": 1.0442865541181403e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.000 size=21 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33527808,
+      "real_time": 9.6669161301892412e+00,
+      "cpu_time": 9.6668213442559541e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.022 size=321 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33429888,
+      "real_time": 1.2676201320274291e+01,
+      "cpu_time": 1.2676296791664980e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=5121 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 31457664,
+      "real_time": 1.8912582611798332e+01,
+      "cpu_time": 1.8910738063695856e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=81921 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 83886144,
+      "real_time": 7.6420774024525926e+01,
+      "cpu_time": 7.6417888215248524e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.038 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33554304,
+      "real_time": 9.7330941558136601e+00,
+      "cpu_time": 9.7324964630438782e+00,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.053 size=19 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33523072,
+      "real_time": 9.8584800350636410e+00,
+      "cpu_time": 9.8585583982155232e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=319 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33416832,
+      "real_time": 1.1864182522300110e+01,
+      "cpu_time": 1.1864087086413200e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.091 size=5119 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 31456896,
+      "real_time": 1.8952971655210398e+01,
+      "cpu_time": 1.8953098360381539e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.084 size=81919 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, folly::F14VectorSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 83886016,
+      "real_time": 5.8654548936830764e+01,
+      "cpu_time": 5.8651849123454625e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=1310719 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33553920,
+      "real_time": 1.8700249586915174e+01,
+      "cpu_time": 1.8700207427314339e+01,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=1.471 size=17 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33553920,
+      "real_time": 9.4014267617853786e+00,
+      "cpu_time": 9.4015052786550637e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.293 size=257 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33038208,
+      "real_time": 8.9376672505607289e+00,
+      "cpu_time": 8.9373429999573872e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.292 size=4097 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 25166208,
+      "real_time": 1.3069779447948466e+01,
+      "cpu_time": 1.3069874650975210e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.336 size=65537 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67108928,
+      "real_time": 1.4989662759898586e+01,
+      "cpu_time": 1.4989551077315088e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.403 size=1048577 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33553408,
+      "real_time": 1.1852917992137709e+01,
+      "cpu_time": 1.1852859268438058e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.488 size=31 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33554304,
+      "real_time": 8.1897823410480051e+00,
+      "cpu_time": 8.1898448556519075e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.833 size=511 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33550336,
+      "real_time": 1.2511456370018964e+01,
+      "cpu_time": 1.2511539824823638e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.902 size=8191 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554176,
+      "real_time": 1.6183686405930761e+01,
+      "cpu_time": 1.6183698774169827e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.880 size=131071 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 134217664,
+      "real_time": 2.3465294239096863e+01,
+      "cpu_time": 2.3464394410854890e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.919 size=2097151 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33553920,
+      "real_time": 4.8162209705237970e+01,
+      "cpu_time": 4.8162189753092782e+01,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=1.353 size=17 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33553920,
+      "real_time": 3.2451848780216629e+01,
+      "cpu_time": 3.2451695986639812e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.261 size=257 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33038208,
+      "real_time": 4.1652224154405680e+01,
+      "cpu_time": 4.1652427789064447e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.362 size=4097 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 25166208,
+      "real_time": 4.5615399161696288e+01,
+      "cpu_time": 4.5615710360484670e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.329 size=65537 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67108928,
+      "real_time": 1.7644592857257885e+02,
+      "cpu_time": 1.7643857066230126e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.401 size=1048577 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33553408,
+      "real_time": 2.2028200493201012e+01,
+      "cpu_time": 2.2028335035303975e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.862 size=31 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33554304,
+      "real_time": 1.9863859281544539e+01,
+      "cpu_time": 1.9863890963137074e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.971 size=511 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33550336,
+      "real_time": 3.1798899875497398e+01,
+      "cpu_time": 3.1798804310031361e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.908 size=8191 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33554176,
+      "real_time": 3.6284305053697288e+01,
+      "cpu_time": 3.6284424835830599e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.890 size=131071 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Hot, google::dense_hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 134217664,
+      "real_time": 1.2029606518334133e+02,
+      "cpu_time": 1.2029413620251684e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.920 size=2097151 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33554434,
+      "real_time": 1.6469233527843528e+02,
+      "cpu_time": 1.6469190843747086e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.248 size=194 num_sets=172961"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33554820,
+      "real_time": 1.6192152323341756e+02,
+      "cpu_time": 1.6192135910727268e+02,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=0.253 size=390 num_sets=86038"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33559160,
+      "real_time": 1.6729739642084112e+02,
+      "cpu_time": 1.6729511930572795e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.250 size=6152 num_sets=5455"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33624756,
+      "real_time": 1.6808602018209902e+02,
+      "cpu_time": 1.6808617153980444e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.250 size=98318 num_sets=342"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 34603140,
+      "real_time": 1.9803011293856579e+02,
+      "cpu_time": 1.9802689747231182e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.249 size=1572870 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33554496,
+      "real_time": 1.9224676886260949e+02,
+      "cpu_time": 1.9224539262935787e+02,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=0.495 size=192 num_sets=174763"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33554628,
+      "real_time": 2.6701718872994104e+02,
+      "cpu_time": 2.6701348806488204e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.497 size=388 num_sets=86481"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33560550,
+      "real_time": 1.9355614145326334e+02,
+      "cpu_time": 1.9355368311902058e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.500 size=6150 num_sets=5457"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33624072,
+      "real_time": 1.9580763880531680e+02,
+      "cpu_time": 1.9580530493151872e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.500 size=98316 num_sets=342"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 34603096,
+      "real_time": 2.5605428418949168e+02,
+      "cpu_time": 2.5605438579832162e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.499 size=1572868 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20973340,
+      "real_time": 2.9560583758939646e+02,
+      "cpu_time": 2.9560303065701822e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.249 size=194 num_sets=10811"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20974200,
+      "real_time": 2.7384548702145963e+02,
+      "cpu_time": 2.7384006646261031e+02,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=0.253 size=390 num_sets=5378"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20978320,
+      "real_time": 2.8178090191891573e+02,
+      "cpu_time": 2.8177394748484159e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.250 size=6152 num_sets=341"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21629960,
+      "real_time": 2.8410030264598083e+02,
+      "cpu_time": 2.8409100770415625e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.250 size=98318 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 22020180,
+      "real_time": 3.1157668959408011e+02,
+      "cpu_time": 3.1157045682641552e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.249 size=1572870 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20972160,
+      "real_time": 2.7743825805085731e+02,
+      "cpu_time": 2.7743558703538946e+02,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=0.494 size=192 num_sets=10923"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20975280,
+      "real_time": 2.8029751939237161e+02,
+      "cpu_time": 2.8029545207503122e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.498 size=388 num_sets=5406"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 21033000,
+      "real_time": 2.8905595119151491e+02,
+      "cpu_time": 2.8905560980366494e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.500 size=6150 num_sets=342"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21629520,
+      "real_time": 2.9034048589032545e+02,
+      "cpu_time": 2.9034146966737427e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.499 size=98316 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 22020152,
+      "real_time": 3.0245998760455689e+02,
+      "cpu_time": 3.0246059005406687e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.499 size=1572868 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33554447,
+      "real_time": 2.1696604583835247e+02,
+      "cpu_time": 2.1696601603955696e+02,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=0.000 size=17 num_sets=1973791"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33554434,
+      "real_time": 3.8604507865343271e+02,
+      "cpu_time": 3.8603953006626796e+02,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=0.000 size=257 num_sets=130562"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33556884,
+      "real_time": 3.8692099292926275e+02,
+      "cpu_time": 3.8691373066702141e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=4349 num_sets=7716"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33586193,
+      "real_time": 4.3747597907544684e+02,
+      "cpu_time": 4.3747419667359225e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=67307 num_sets=499"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33802336,
+      "real_time": 4.8625060628879794e+02,
+      "cpu_time": 4.8624115138079787e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=1056323 num_sets=32"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33554465,
+      "real_time": 2.6077627456847051e+02,
+      "cpu_time": 2.6077612627708106e+02,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=35 num_sets=958699"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33554906,
+      "real_time": 4.2207463389857355e+02,
+      "cpu_time": 4.2206845434166917e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=539 num_sets=62254"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33554493,
+      "real_time": 3.0057716384538907e+02,
+      "cpu_time": 3.0056864474157419e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=4347 num_sets=7719"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33585195,
+      "real_time": 3.0492167118483326e+02,
+      "cpu_time": 3.0492206777421490e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=67305 num_sets=499"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33802272,
+      "real_time": 3.0190413532182816e+02,
+      "cpu_time": 3.0190558409801821e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1056321 num_sets=32"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971540,
+      "real_time": 4.2840587255694459e+02,
+      "cpu_time": 4.2839877114409103e+02,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=0.000 size=17 num_sets=123362"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20973770,
+      "real_time": 3.7833672839360804e+02,
+      "cpu_time": 3.7832969032272206e+02,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=0.000 size=257 num_sets=8161"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 21005670,
+      "real_time": 6.0898641479058836e+02,
+      "cpu_time": 6.0896447630567502e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=4349 num_sets=483"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21538240,
+      "real_time": 5.9444127475377445e+02,
+      "cpu_time": 5.9442606438594987e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=67307 num_sets=32"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 21126460,
+      "real_time": 5.8703326833444135e+02,
+      "cpu_time": 5.8701971939455439e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=1056323 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971650,
+      "real_time": 5.4341633923590632e+02,
+      "cpu_time": 5.4340620299309933e+02,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=35 num_sets=59919"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20972490,
+      "real_time": 3.6522217331778666e+02,
+      "cpu_time": 3.6521844320821731e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=539 num_sets=3891"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20996010,
+      "real_time": 3.5483715984624200e+02,
+      "cpu_time": 3.5483654265739290e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=4347 num_sets=483"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21537600,
+      "real_time": 3.7237141693996006e+02,
+      "cpu_time": 3.7237066279433992e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=67305 num_sets=32"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, std::unordered_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 21126420,
+      "real_time": 3.6796735073922372e+02,
+      "cpu_time": 3.6795754477095210e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1056321 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33554451,
+      "real_time": 3.8282891162342118e+01,
+      "cpu_time": 3.8282939124844091e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.039 size=21 num_sets=1597831"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33554451,
+      "real_time": 1.1068459698540700e+02,
+      "cpu_time": 1.1068491220432499e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=321 num_sets=104531"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33557913,
+      "real_time": 1.1214193084233972e+02,
+      "cpu_time": 1.1214252760591651e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=5121 num_sets=6553"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33587610,
+      "real_time": 1.2554300787223039e+02,
+      "cpu_time": 1.2554286160879367e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=81921 num_sets=410"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 34078746,
+      "real_time": 1.2571471129426665e+02,
+      "cpu_time": 1.2571462321414968e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.038 size=1310721 num_sets=26"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33554437,
+      "real_time": 2.3920410529517483e+01,
+      "cpu_time": 2.3919677269494446e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.071 size=19 num_sets=1766023"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33554653,
+      "real_time": 9.2519238422337892e+01,
+      "cpu_time": 9.2519439375501776e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.085 size=319 num_sets=105187"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33555045,
+      "real_time": 1.6251181140009700e+02,
+      "cpu_time": 1.6251001135596715e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=5119 num_sets=6555"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33586790,
+      "real_time": 1.2275993632290177e+02,
+      "cpu_time": 1.2275961617649044e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=81919 num_sets=410"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 34078694,
+      "real_time": 1.3117582830072817e+02,
+      "cpu_time": 1.3117519820448558e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=1310719 num_sets=26"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971750,
+      "real_time": 1.0062036531676122e+02,
+      "cpu_time": 1.0062050711080917e+02,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.047 size=25 num_sets=83887"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20974800,
+      "real_time": 1.0240035232845705e+02,
+      "cpu_time": 1.0239829590746319e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=385 num_sets=5448"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 21015900,
+      "real_time": 1.1731523914732951e+02,
+      "cpu_time": 1.1730081956992242e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=6145 num_sets=342"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21627100,
+      "real_time": 1.0892221537842870e+02,
+      "cpu_time": 1.0892169657514110e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=98305 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 22020110,
+      "real_time": 1.8498906919196975e+02,
+      "cpu_time": 1.8498415198650798e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.046 size=1572865 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971630,
+      "real_time": 9.7178498940839404e+01,
+      "cpu_time": 9.7176454047648946e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.087 size=23 num_sets=91181"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20973080,
+      "real_time": 9.4690294992943123e+01,
+      "cpu_time": 9.4686688602748760e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.103 size=383 num_sets=5476"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 21009060,
+      "real_time": 9.7804448631758547e+01,
+      "cpu_time": 9.7800828928076015e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.104 size=6143 num_sets=342"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21626660,
+      "real_time": 9.8020559404400828e+01,
+      "cpu_time": 9.8018329968687183e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.104 size=98303 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14ValueSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 22020082,
+      "real_time": 1.3867544440275063e+02,
+      "cpu_time": 1.3866296106438969e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.103 size=1572863 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33554450,
+      "real_time": 1.4202586326495040e+02,
+      "cpu_time": 1.4202026977044338e+02,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.047 size=25 num_sets=1342178"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33554675,
+      "real_time": 2.0396830615442940e+02,
+      "cpu_time": 2.0396325978421467e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=385 num_sets=87155"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33557845,
+      "real_time": 1.9969927416971586e+02,
+      "cpu_time": 1.9969797357370965e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=6145 num_sets=5461"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33620310,
+      "real_time": 2.2740486276930591e+02,
+      "cpu_time": 2.2740482024105492e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=98305 num_sets=342"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 34603030,
+      "real_time": 3.5716774730712046e+02,
+      "cpu_time": 3.5716656211898459e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.046 size=1572865 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33554447,
+      "real_time": 1.2386442596667379e+02,
+      "cpu_time": 1.2385900405395633e+02,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.087 size=23 num_sets=1458889"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33554630,
+      "real_time": 1.8328336742186551e+02,
+      "cpu_time": 1.8327969925460286e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.103 size=383 num_sets=87610"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33559209,
+      "real_time": 2.3531831145044430e+02,
+      "cpu_time": 2.3531901201842140e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.104 size=6143 num_sets=5463"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33619626,
+      "real_time": 2.3022716454120857e+02,
+      "cpu_time": 2.3022806312596450e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.104 size=98303 num_sets=342"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 34602986,
+      "real_time": 4.3161571619834933e+02,
+      "cpu_time": 4.3161222936078548e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.103 size=1572863 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971750,
+      "real_time": 2.8207455085889819e+02,
+      "cpu_time": 2.8207373538214193e+02,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.047 size=25 num_sets=83887"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20974800,
+      "real_time": 2.7381521519205671e+02,
+      "cpu_time": 2.7381411460417019e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=385 num_sets=5448"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 21015900,
+      "real_time": 3.3876967024315678e+02,
+      "cpu_time": 3.3876563397232485e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=6145 num_sets=342"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21627100,
+      "real_time": 5.4161980680723070e+02,
+      "cpu_time": 5.4160140892671825e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=98305 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 22020110,
+      "real_time": 5.9270986028861864e+02,
+      "cpu_time": 5.9268994787036479e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.046 size=1572865 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971630,
+      "real_time": 2.6740592177259254e+02,
+      "cpu_time": 2.6740349166950813e+02,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.087 size=23 num_sets=91181"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20973080,
+      "real_time": 2.3998365758771649e+02,
+      "cpu_time": 2.3997794396440176e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.103 size=383 num_sets=5476"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 21009060,
+      "real_time": 3.4645614771388824e+02,
+      "cpu_time": 3.4643760891722678e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.104 size=6143 num_sets=342"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21626660,
+      "real_time": 3.7742019603748048e+02,
+      "cpu_time": 3.7740443452667216e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.104 size=98303 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14NodeSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 22020082,
+      "real_time": 6.2203259020377834e+02,
+      "cpu_time": 6.2202331848725214e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.103 size=1572863 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33554451,
+      "real_time": 5.9132420116955743e+01,
+      "cpu_time": 5.9132419302611950e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.039 size=21 num_sets=1597831"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33554451,
+      "real_time": 1.4992756584324246e+02,
+      "cpu_time": 1.4992732424681446e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=321 num_sets=104531"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33557913,
+      "real_time": 1.5317040190949470e+02,
+      "cpu_time": 1.5317023356012001e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=5121 num_sets=6553"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33587610,
+      "real_time": 1.3450759516992565e+02,
+      "cpu_time": 1.3450710154729035e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=81921 num_sets=410"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 34078746,
+      "real_time": 1.2949766766676740e+02,
+      "cpu_time": 1.2949707961672101e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.038 size=1310721 num_sets=26"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33554437,
+      "real_time": 3.1846726728628976e+01,
+      "cpu_time": 3.1846729778272394e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.071 size=19 num_sets=1766023"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33554653,
+      "real_time": 1.4764231895195269e+02,
+      "cpu_time": 1.4764212501315117e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.085 size=319 num_sets=105187"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33555045,
+      "real_time": 1.6636028923976835e+02,
+      "cpu_time": 1.6635592945863672e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=5119 num_sets=6555"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33586790,
+      "real_time": 1.5324053708302796e+02,
+      "cpu_time": 1.5323790374132312e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=81919 num_sets=410"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 34078694,
+      "real_time": 1.8169143433762136e+02,
+      "cpu_time": 1.8168983582528131e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=1310719 num_sets=26"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971650,
+      "real_time": 1.2672696699286014e+02,
+      "cpu_time": 1.2672579787480733e+02,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.039 size=21 num_sets=99865"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20974140,
+      "real_time": 1.3409964331871868e+02,
+      "cpu_time": 1.3409760905568908e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=321 num_sets=6534"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20996100,
+      "real_time": 1.1108426925863613e+02,
+      "cpu_time": 1.1108289510913355e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=5121 num_sets=410"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21299460,
+      "real_time": 1.0875997781867044e+02,
+      "cpu_time": 1.0875500444617683e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=81921 num_sets=26"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 20971536,
+      "real_time": 1.1077364167825574e+02,
+      "cpu_time": 1.1076244253165510e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=1310721 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971630,
+      "real_time": 1.1065585506830179e+02,
+      "cpu_time": 1.1065072800737750e+02,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.071 size=19 num_sets=110377"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20974250,
+      "real_time": 1.2025019579090470e+02,
+      "cpu_time": 1.2024773028830302e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.085 size=319 num_sets=6575"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20987900,
+      "real_time": 1.0897974558798867e+02,
+      "cpu_time": 1.0897970602105390e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=5119 num_sets=410"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21298940,
+      "real_time": 1.1229813124933330e+02,
+      "cpu_time": 1.1229710051295415e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=81919 num_sets=26"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, folly::F14VectorSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 20971504,
+      "real_time": 8.7907732215490412e+01,
+      "cpu_time": 8.7905616878972765e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=1310719 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33554447,
+      "real_time": 4.6942176699741417e+01,
+      "cpu_time": 4.6942181791857280e+01,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=1.552 size=17 num_sets=1973791"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33554434,
+      "real_time": 4.2564377927647847e+01,
+      "cpu_time": 4.2562576200801843e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.338 size=257 num_sets=130562"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33558527,
+      "real_time": 4.2950939080090009e+01,
+      "cpu_time": 4.2951013344513406e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.323 size=4097 num_sets=8191"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554944,
+      "real_time": 5.0225041139707344e+01,
+      "cpu_time": 5.0224394265122143e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.322 size=65537 num_sets=512"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554464,
+      "real_time": 4.6359430269707488e+01,
+      "cpu_time": 4.6359512671704515e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.321 size=1048577 num_sets=32"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33554462,
+      "real_time": 4.2461669075674607e+01,
+      "cpu_time": 4.2461551342970694e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.887 size=31 num_sets=1082402"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33554815,
+      "real_time": 4.5339697617479018e+01,
+      "cpu_time": 4.5339817310894233e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.870 size=511 num_sets=65665"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33558527,
+      "real_time": 4.6283191003900782e+01,
+      "cpu_time": 4.6282413140513206e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.869 size=8191 num_sets=4097"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33685247,
+      "real_time": 5.1728836551079098e+01,
+      "cpu_time": 5.1728834287578437e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.868 size=131071 num_sets=257"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 35651567,
+      "real_time": 5.0517806986829186e+01,
+      "cpu_time": 5.0517700077505104e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.866 size=2097151 num_sets=17"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971540,
+      "real_time": 1.4756751194386069e+02,
+      "cpu_time": 1.4756639464726561e+02,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=1.552 size=17 num_sets=123362"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20973770,
+      "real_time": 1.2075420750448991e+02,
+      "cpu_time": 1.2075154976904217e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.337 size=257 num_sets=8161"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20976640,
+      "real_time": 1.2093730550918575e+02,
+      "cpu_time": 1.2093587824362268e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.323 size=4097 num_sets=512"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971840,
+      "real_time": 1.1880272888534464e+02,
+      "cpu_time": 1.1880287495038873e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.322 size=65537 num_sets=32"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 20971540,
+      "real_time": 1.9265696481355050e+02,
+      "cpu_time": 1.9265420627192017e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.322 size=1048577 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971810,
+      "real_time": 1.0697770992305065e+02,
+      "cpu_time": 1.0697541838303201e+02,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.886 size=31 num_sets=67651"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20976550,
+      "real_time": 1.1334653536973477e+02,
+      "cpu_time": 1.1334638889610635e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.871 size=511 num_sets=4105"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 21050870,
+      "real_time": 9.9483963187044239e+01,
+      "cpu_time": 9.9483521156150445e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.871 size=8191 num_sets=257"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 20053863,
+      "real_time": 9.5181617483198366e+01,
+      "cpu_time": 9.5181425643540905e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.867 size=131071 num_sets=17"
+    },
+    {
+      "name": "BM<InsertManyUnordered_Cold, google::dense_hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 20971510,
+      "real_time": 1.3684087593358450e+02,
+      "cpu_time": 1.3683923308331623e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.865 size=2097151 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33572864,
+      "real_time": 4.3747468999729769e+01,
+      "cpu_time": 4.3747613012716101e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.248 size=194 num_sets=1352"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33596160,
+      "real_time": 4.6754571902537094e+01,
+      "cpu_time": 4.6754541263085365e+01,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=0.252 size=390 num_sets=673"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33860608,
+      "real_time": 5.3513884701193682e+01,
+      "cpu_time": 5.3514239230420770e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.251 size=6152 num_sets=43"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 37754112,
+      "real_time": 5.4546818715626188e+01,
+      "cpu_time": 5.4544529109809368e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.251 size=98318 num_sets=3"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 100663680,
+      "real_time": 5.3359729809537221e+01,
+      "cpu_time": 5.3358803681719685e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.249 size=1572870 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33570816,
+      "real_time": 4.5935034396453219e+01,
+      "cpu_time": 4.5934182267121422e+01,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=0.495 size=192 num_sets=1366"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33572864,
+      "real_time": 4.7126062780678659e+01,
+      "cpu_time": 4.7125607186814044e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.498 size=388 num_sets=676"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33849600,
+      "real_time": 5.0995730625746901e+01,
+      "cpu_time": 5.0995768339942025e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.500 size=6150 num_sets=43"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 37753344,
+      "real_time": 5.1073640569183027e+01,
+      "cpu_time": 5.1073211183621957e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.499 size=98316 num_sets=3"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 100663552,
+      "real_time": 5.2766242557989713e+01,
+      "cpu_time": 5.2766207345830921e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.499 size=1572868 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33572864,
+      "real_time": 4.3110419474944372e+01,
+      "cpu_time": 4.3109930805982906e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.248 size=194 num_sets=1352"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33596160,
+      "real_time": 4.5613126036788991e+01,
+      "cpu_time": 4.5612994312447498e+01,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=0.253 size=390 num_sets=673"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33860608,
+      "real_time": 5.1905961219027240e+01,
+      "cpu_time": 5.1905369182988530e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.249 size=6152 num_sets=43"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 37754112,
+      "real_time": 5.1529260824656504e+01,
+      "cpu_time": 5.1528717163320650e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.250 size=98318 num_sets=3"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 100663680,
+      "real_time": 5.4375112821841675e+01,
+      "cpu_time": 5.4375279226833150e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.249 size=1572870 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33570816,
+      "real_time": 4.5676331313962379e+01,
+      "cpu_time": 4.5676232981633717e+01,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=0.496 size=192 num_sets=1366"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33572864,
+      "real_time": 4.7843302741264083e+01,
+      "cpu_time": 4.7843496610842692e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.501 size=388 num_sets=676"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33849600,
+      "real_time": 5.1985711203019953e+01,
+      "cpu_time": 5.1985630081259941e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.500 size=6150 num_sets=43"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 37753344,
+      "real_time": 5.1357797712594056e+01,
+      "cpu_time": 5.1357622837337374e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.501 size=98316 num_sets=3"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 100663552,
+      "real_time": 5.4692921655720617e+01,
+      "cpu_time": 5.4692924316833874e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.499 size=1572868 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556096,
+      "real_time": 7.0121988898608080e+01,
+      "cpu_time": 7.0121288572995340e+01,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=0.000 size=17 num_sets=15421"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33586816,
+      "real_time": 7.6555228860465391e+01,
+      "cpu_time": 7.6554403459945263e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=0.000 size=257 num_sets=1021"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33956992,
+      "real_time": 7.9649973963278740e+01,
+      "cpu_time": 7.9650427693973029e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=4349 num_sets=61"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 34461184,
+      "real_time": 1.0446925946337716e+02,
+      "cpu_time": 1.0446887530036642e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=67307 num_sets=4"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67604672,
+      "real_time": 1.3836090631376547e+02,
+      "cpu_time": 1.3836098369059491e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=1056323 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33555200,
+      "real_time": 5.4617644197586586e+01,
+      "cpu_time": 5.4616531744720838e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=35 num_sets=7490"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33599104,
+      "real_time": 5.6916559721155380e+01,
+      "cpu_time": 5.6914341703914239e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=539 num_sets=487"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33941376,
+      "real_time": 5.4950093570436714e+01,
+      "cpu_time": 5.4949428420365109e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=4347 num_sets=61"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 34460160,
+      "real_time": 6.3210795524525757e+01,
+      "cpu_time": 6.3210512835723840e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=67305 num_sets=4"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 67604544,
+      "real_time": 8.9922935885772006e+01,
+      "cpu_time": 8.9919441302656537e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1056321 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556096,
+      "real_time": 7.5330122561675168e+01,
+      "cpu_time": 7.5329113613215426e+01,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=0.000 size=17 num_sets=15421"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33586816,
+      "real_time": 8.0455250616788177e+01,
+      "cpu_time": 8.0452223545076535e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=0.000 size=257 num_sets=1021"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33956992,
+      "real_time": 8.6638496899968871e+01,
+      "cpu_time": 8.6637263218125085e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=4349 num_sets=61"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 34461184,
+      "real_time": 1.0398931154082658e+02,
+      "cpu_time": 1.0398835692934777e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=67307 num_sets=4"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67604672,
+      "real_time": 2.0854391084505372e+02,
+      "cpu_time": 2.0854227215242452e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=1056323 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33555200,
+      "real_time": 5.2418507921225057e+01,
+      "cpu_time": 5.2418632313284213e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=35 num_sets=7490"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33599104,
+      "real_time": 5.3959906005629762e+01,
+      "cpu_time": 5.3959628893719191e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=539 num_sets=487"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33941376,
+      "real_time": 5.8305084390883415e+01,
+      "cpu_time": 5.8305104689907161e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=4347 num_sets=61"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 34460160,
+      "real_time": 6.7986112070529956e+01,
+      "cpu_time": 6.7985921046227702e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=67305 num_sets=4"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, std::unordered_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 67604544,
+      "real_time": 1.4471846509519756e+02,
+      "cpu_time": 1.4471776755125413e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1056321 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556992,
+      "real_time": 1.0834722722923186e+01,
+      "cpu_time": 1.0834777592702569e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.039 size=21 num_sets=12484"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33568896,
+      "real_time": 1.1058596631194122e+01,
+      "cpu_time": 1.1058670472834160e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=321 num_sets=817"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34085376,
+      "real_time": 1.0733075435789072e+01,
+      "cpu_time": 1.0733060154578833e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=5121 num_sets=52"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971776,
+      "real_time": 1.1019735298410986e+01,
+      "cpu_time": 1.1019812580526027e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=81921 num_sets=4"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 83886144,
+      "real_time": 1.1104054974788196e+01,
+      "cpu_time": 1.1104048494581807e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.038 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33556736,
+      "real_time": 1.0832588638497853e+01,
+      "cpu_time": 1.0832652824171774e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.072 size=19 num_sets=13798"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33563904,
+      "real_time": 1.0998235617690014e+01,
+      "cpu_time": 1.0997284314727157e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=319 num_sets=822"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34072064,
+      "real_time": 1.1612317704587634e+01,
+      "cpu_time": 1.1612395861886174e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.088 size=5119 num_sets=52"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 20971264,
+      "real_time": 1.2718824754461945e+01,
+      "cpu_time": 1.2718767166317207e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=81919 num_sets=4"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 83886016,
+      "real_time": 1.2657689006154328e+01,
+      "cpu_time": 1.2657730663944085e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.084 size=1310719 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33555200,
+      "real_time": 1.0885400567917840e+01,
+      "cpu_time": 1.0885472951989152e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.047 size=25 num_sets=10486"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33559680,
+      "real_time": 1.1744869790411032e+01,
+      "cpu_time": 1.1744871226429053e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=385 num_sets=681"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33822080,
+      "real_time": 1.5376108038794710e+01,
+      "cpu_time": 1.5376211043195774e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=6145 num_sets=43"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 37749120,
+      "real_time": 1.6560599503713519e+01,
+      "cpu_time": 1.6560465806899494e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=98305 num_sets=3"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 100663360,
+      "real_time": 1.0471143689428594e+02,
+      "cpu_time": 1.0470956124453095e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.046 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33555712,
+      "real_time": 1.1106588516134801e+01,
+      "cpu_time": 1.1106640443209615e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.087 size=23 num_sets=11398"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33581440,
+      "real_time": 1.1726567217717120e+01,
+      "cpu_time": 1.1726401935112019e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.104 size=383 num_sets=685"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33811072,
+      "real_time": 1.4550652570181381e+01,
+      "cpu_time": 1.4550747814202635e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.107 size=6143 num_sets=43"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 37748352,
+      "real_time": 1.7627563511131736e+01,
+      "cpu_time": 1.7627136914485163e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.103 size=98303 num_sets=3"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14ValueSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 100663232,
+      "real_time": 7.0182553314371660e+01,
+      "cpu_time": 7.0182098087206796e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.102 size=1572863 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33555200,
+      "real_time": 3.5822499510033680e+01,
+      "cpu_time": 3.5822467814217042e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.048 size=25 num_sets=10486"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33559680,
+      "real_time": 4.6865014418640492e+01,
+      "cpu_time": 4.6865138106167009e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=385 num_sets=681"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33822080,
+      "real_time": 4.7619941715197385e+01,
+      "cpu_time": 4.7619891266300129e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.046 size=6145 num_sets=43"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 37749120,
+      "real_time": 4.8368646786365431e+01,
+      "cpu_time": 4.8368749867549013e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=98305 num_sets=3"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 100663360,
+      "real_time": 5.5243229654797823e+01,
+      "cpu_time": 5.5242722138421108e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.046 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33555712,
+      "real_time": 3.6575916585541215e+01,
+      "cpu_time": 3.6575437886692768e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.088 size=23 num_sets=11398"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33581440,
+      "real_time": 4.7496105909815547e+01,
+      "cpu_time": 4.7495845443219189e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.104 size=383 num_sets=685"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33811072,
+      "real_time": 4.8753636219158430e+01,
+      "cpu_time": 4.8753845752077893e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.107 size=6143 num_sets=43"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 37748352,
+      "real_time": 5.2992323655817209e+01,
+      "cpu_time": 5.2992052288769585e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.103 size=98303 num_sets=3"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 100663232,
+      "real_time": 6.6259272525187015e+01,
+      "cpu_time": 6.6259132192383447e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.102 size=1572863 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33555200,
+      "real_time": 3.5693759218372733e+01,
+      "cpu_time": 3.5693607607769970e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.046 size=25 num_sets=10486"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33559680,
+      "real_time": 4.7888156728295108e+01,
+      "cpu_time": 4.7888189309275120e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=385 num_sets=681"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33822080,
+      "real_time": 5.0260402552778835e+01,
+      "cpu_time": 5.0260605320515445e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=6145 num_sets=43"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 37749120,
+      "real_time": 5.0345438675443638e+01,
+      "cpu_time": 5.0344729201623970e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=98305 num_sets=3"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 100663360,
+      "real_time": 7.2195809319180654e+01,
+      "cpu_time": 7.2195725475476650e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.046 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33555712,
+      "real_time": 3.8127377203539126e+01,
+      "cpu_time": 3.8127237979618648e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.087 size=23 num_sets=11398"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33581440,
+      "real_time": 4.8542653273169350e+01,
+      "cpu_time": 4.8542655794403728e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.104 size=383 num_sets=685"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33811072,
+      "real_time": 5.2815755242481366e+01,
+      "cpu_time": 5.2815740476962759e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.107 size=6143 num_sets=43"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 37748352,
+      "real_time": 6.0591380773186735e+01,
+      "cpu_time": 6.0591188351750063e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.104 size=98303 num_sets=3"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14NodeSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 100663232,
+      "real_time": 1.3130762550783081e+02,
+      "cpu_time": 1.3130610571891600e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.102 size=1572863 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556992,
+      "real_time": 8.5922290910121717e+00,
+      "cpu_time": 8.5922584181239703e+00,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.040 size=21 num_sets=12484"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33568896,
+      "real_time": 8.2982550582570394e+00,
+      "cpu_time": 8.2983103168218104e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.040 size=321 num_sets=817"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34085376,
+      "real_time": 9.3165062824645108e+00,
+      "cpu_time": 9.3156554587961757e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=5121 num_sets=52"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971776,
+      "real_time": 1.4232838539169123e+01,
+      "cpu_time": 1.4233680733579833e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=81921 num_sets=4"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 83886144,
+      "real_time": 3.2434793107971480e+01,
+      "cpu_time": 3.2434538843522269e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.038 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33556736,
+      "real_time": 9.8211578710184995e+00,
+      "cpu_time": 9.8212178622022286e+00,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.070 size=19 num_sets=13798"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33563904,
+      "real_time": 8.2441891263244838e+00,
+      "cpu_time": 8.2442626459741657e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.085 size=319 num_sets=822"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34072064,
+      "real_time": 8.7598790396507891e+00,
+      "cpu_time": 8.7597829412202444e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=5119 num_sets=52"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 20971264,
+      "real_time": 1.4889076135475163e+01,
+      "cpu_time": 1.4887941089360465e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.087 size=81919 num_sets=4"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 83886016,
+      "real_time": 2.3394128674606232e+01,
+      "cpu_time": 2.3394109883590154e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=1310719 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556992,
+      "real_time": 9.4051274374827418e+00,
+      "cpu_time": 9.4050827321363926e+00,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.039 size=21 num_sets=12484"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33568896,
+      "real_time": 8.6020587556163246e+00,
+      "cpu_time": 8.6021040429519537e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=321 num_sets=817"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34085376,
+      "real_time": 1.1981798641804117e+01,
+      "cpu_time": 1.1981884811854311e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=5121 num_sets=52"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971776,
+      "real_time": 1.8046314641164834e+01,
+      "cpu_time": 1.8045487325469228e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=81921 num_sets=4"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 83886144,
+      "real_time": 7.7123102350426649e+01,
+      "cpu_time": 7.7121737613783026e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.038 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33556736,
+      "real_time": 9.6694247830538966e+00,
+      "cpu_time": 9.6693773792436044e+00,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.070 size=19 num_sets=13798"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33563904,
+      "real_time": 8.9577847086317366e+00,
+      "cpu_time": 8.9578428063894773e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=319 num_sets=822"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34072064,
+      "real_time": 1.1390602557573558e+01,
+      "cpu_time": 1.1390491576952632e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.085 size=5119 num_sets=52"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 20971264,
+      "real_time": 1.8058374167044537e+01,
+      "cpu_time": 1.8058552646161328e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.087 size=81919 num_sets=4"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, folly::F14VectorSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 83886016,
+      "real_time": 5.8235501775452221e+01,
+      "cpu_time": 5.8234619307697770e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=1310719 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556096,
+      "real_time": 1.6909964841096329e+01,
+      "cpu_time": 1.6909998350226374e+01,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=1.552 size=17 num_sets=15421"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33586816,
+      "real_time": 8.0511201595900896e+00,
+      "cpu_time": 8.0511707034231712e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.336 size=257 num_sets=1021"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33562624,
+      "real_time": 8.0374024730209381e+00,
+      "cpu_time": 8.0374487108155357e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.323 size=4097 num_sets=64"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554944,
+      "real_time": 8.4132376280604646e+00,
+      "cpu_time": 8.4126824649002589e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.325 size=65537 num_sets=4"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67108928,
+      "real_time": 8.6739350692549682e+00,
+      "cpu_time": 8.6739805916894852e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.324 size=1048577 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33557376,
+      "real_time": 1.1934074263431606e+01,
+      "cpu_time": 1.1933657774652335e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.881 size=31 num_sets=8457"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33619712,
+      "real_time": 7.2954582687115108e+00,
+      "cpu_time": 7.2955023232051630e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.872 size=511 num_sets=514"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34598784,
+      "real_time": 9.9152813801771948e+00,
+      "cpu_time": 9.9153380650860630e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.870 size=8191 num_sets=33"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 25165632,
+      "real_time": 1.0369815592322420e+01,
+      "cpu_time": 1.0369893154280065e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.867 size=131071 num_sets=3"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 134217664,
+      "real_time": 1.1765776190400418e+01,
+      "cpu_time": 1.1765792489124580e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.867 size=2097151 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556096,
+      "real_time": 4.0611322734972326e+01,
+      "cpu_time": 4.0608795880191721e+01,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=1.553 size=17 num_sets=15421"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33586816,
+      "real_time": 5.4147003697351884e+01,
+      "cpu_time": 5.4144572709734895e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.339 size=257 num_sets=1021"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33562624,
+      "real_time": 5.7684452608700553e+01,
+      "cpu_time": 5.7683024843355547e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.327 size=4097 num_sets=64"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554944,
+      "real_time": 5.9153492549356400e+01,
+      "cpu_time": 5.9152235747985429e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.326 size=65537 num_sets=4"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67108928,
+      "real_time": 1.5926342288725854e+02,
+      "cpu_time": 1.5925848243322923e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.323 size=1048577 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33557376,
+      "real_time": 2.4239537946148438e+01,
+      "cpu_time": 2.4238337556523931e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.876 size=31 num_sets=8457"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33619712,
+      "real_time": 3.0193964780392278e+01,
+      "cpu_time": 3.0193953892332690e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.870 size=511 num_sets=514"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34598784,
+      "real_time": 3.4152215516948758e+01,
+      "cpu_time": 3.4151137999550166e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.869 size=8191 num_sets=33"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 25165632,
+      "real_time": 3.6085595524657009e+01,
+      "cpu_time": 3.6083920999862194e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.870 size=131071 num_sets=3"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Hot, google::dense_hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 134217664,
+      "real_time": 8.4970828256528520e+01,
+      "cpu_time": 8.4969479948636859e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.866 size=2097151 num_sets=1"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33554434,
+      "real_time": 1.3288106888831524e+02,
+      "cpu_time": 1.3288100928777382e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.248 size=194 num_sets=172961"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33554820,
+      "real_time": 9.9899256333586308e+01,
+      "cpu_time": 9.9898729362888645e+01,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=0.253 size=390 num_sets=86038"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33559160,
+      "real_time": 1.0290114290585853e+02,
+      "cpu_time": 1.0290029994788810e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.250 size=6152 num_sets=5455"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33624756,
+      "real_time": 7.4286131346059150e+01,
+      "cpu_time": 7.4283914030464786e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.250 size=98318 num_sets=342"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 34603140,
+      "real_time": 5.5656846499550220e+01,
+      "cpu_time": 5.5656131379977580e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.249 size=1572870 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33554496,
+      "real_time": 1.1702384900509152e+02,
+      "cpu_time": 1.1702404577917056e+02,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=0.495 size=192 num_sets=174763"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33554628,
+      "real_time": 8.7220067952486175e+01,
+      "cpu_time": 8.7220108981709330e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.497 size=388 num_sets=86481"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33560550,
+      "real_time": 9.4685172110278302e+01,
+      "cpu_time": 9.4685220027668535e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.500 size=6150 num_sets=5457"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33624072,
+      "real_time": 6.6266254361780170e+01,
+      "cpu_time": 6.6262883864889488e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.500 size=98316 num_sets=342"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 34603096,
+      "real_time": 5.6376511782796385e+01,
+      "cpu_time": 5.6375194953664653e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.499 size=1572868 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20973340,
+      "real_time": 2.4745442060179369e+02,
+      "cpu_time": 2.4745376778329836e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.247 size=194 num_sets=10811"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20974200,
+      "real_time": 2.4861046126439203e+02,
+      "cpu_time": 2.4860969319455097e+02,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=0.253 size=390 num_sets=5378"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20978320,
+      "real_time": 2.5089148331251454e+02,
+      "cpu_time": 2.5089032405837094e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.250 size=6152 num_sets=341"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21629960,
+      "real_time": 2.4246927746781159e+02,
+      "cpu_time": 2.4246686235200977e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.251 size=98318 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 22020180,
+      "real_time": 1.5133569226903879e+02,
+      "cpu_time": 1.5133567273290535e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.249 size=1572870 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20972160,
+      "real_time": 2.3741170824448974e+02,
+      "cpu_time": 2.3736257905712176e+02,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=0.494 size=192 num_sets=10923"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20975280,
+      "real_time": 2.4036205957349728e+02,
+      "cpu_time": 2.4036028343839166e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.498 size=388 num_sets=5406"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 21033000,
+      "real_time": 2.3931680038278762e+02,
+      "cpu_time": 2.3931614610372353e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.500 size=6150 num_sets=342"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21629520,
+      "real_time": 2.3438378144103484e+02,
+      "cpu_time": 2.3438406261442898e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.500 size=98316 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 22020152,
+      "real_time": 1.5366390370764861e+02,
+      "cpu_time": 1.5366269020301777e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.499 size=1572868 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33554447,
+      "real_time": 2.0111743983466656e+02,
+      "cpu_time": 2.0111751887909534e+02,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=0.000 size=17 num_sets=1973791"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33554434,
+      "real_time": 3.1145239196453628e+02,
+      "cpu_time": 3.1144955754580769e+02,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=0.000 size=257 num_sets=130562"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33556884,
+      "real_time": 3.6416481756293877e+02,
+      "cpu_time": 3.6416025370535078e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=4349 num_sets=7716"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33586193,
+      "real_time": 3.3869966405754224e+02,
+      "cpu_time": 3.3869308230317654e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=67307 num_sets=499"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33802336,
+      "real_time": 3.5766832647661147e+02,
+      "cpu_time": 3.5765778634347868e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=1056323 num_sets=32"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33554465,
+      "real_time": 1.9935367424077455e+02,
+      "cpu_time": 1.9934929917668165e+02,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=35 num_sets=958699"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33554906,
+      "real_time": 1.3788850497924452e+02,
+      "cpu_time": 1.3788552237339493e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=539 num_sets=62254"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33554493,
+      "real_time": 1.4490813473518273e+02,
+      "cpu_time": 1.4490530803134828e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=4347 num_sets=7719"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33585195,
+      "real_time": 1.3908648638318365e+02,
+      "cpu_time": 1.3908332754956311e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=67305 num_sets=499"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33802272,
+      "real_time": 1.4214129469383650e+02,
+      "cpu_time": 1.4214013747362748e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1056321 num_sets=32"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971540,
+      "real_time": 4.0143470784205402e+02,
+      "cpu_time": 4.0142607223879281e+02,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=0.000 size=17 num_sets=123362"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20973770,
+      "real_time": 3.0782407529343146e+02,
+      "cpu_time": 3.0781672813236401e+02,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=0.000 size=257 num_sets=8161"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 21005670,
+      "real_time": 5.0497942571337097e+02,
+      "cpu_time": 5.0496467111030165e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=4349 num_sets=483"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21538240,
+      "real_time": 4.6946025651694316e+02,
+      "cpu_time": 4.6944710621666644e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=67307 num_sets=32"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 21126460,
+      "real_time": 2.8443464259058067e+02,
+      "cpu_time": 2.8443206221011025e+02,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=1056323 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971650,
+      "real_time": 2.8006516335839774e+02,
+      "cpu_time": 2.8006466362929541e+02,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=35 num_sets=59919"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20972490,
+      "real_time": 2.6392052911838806e+02,
+      "cpu_time": 2.6391879023420239e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=539 num_sets=3891"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20996010,
+      "real_time": 2.8699529675789648e+02,
+      "cpu_time": 2.8698989226996559e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=4347 num_sets=483"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21537600,
+      "real_time": 2.5571415465261188e+02,
+      "cpu_time": 2.5570351431913511e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=67305 num_sets=32"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, std::unordered_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 21126420,
+      "real_time": 2.2579227200536232e+02,
+      "cpu_time": 2.2578911694460649e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1056321 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33554451,
+      "real_time": 3.7009769831014076e+01,
+      "cpu_time": 3.7009409660719989e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.039 size=21 num_sets=1597831"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33554451,
+      "real_time": 5.9448959621070870e+01,
+      "cpu_time": 5.9448553755204756e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=321 num_sets=104531"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33557913,
+      "real_time": 5.7955083109208751e+01,
+      "cpu_time": 5.7954831040898036e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=5121 num_sets=6553"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33587610,
+      "real_time": 2.3285704696098200e+01,
+      "cpu_time": 2.3285644527835519e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=81921 num_sets=410"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 34078746,
+      "real_time": 1.2000192757086772e+01,
+      "cpu_time": 1.1999803044389317e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.038 size=1310721 num_sets=26"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33554437,
+      "real_time": 2.2201892124887305e+01,
+      "cpu_time": 2.2201816707578583e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.071 size=19 num_sets=1766023"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33554653,
+      "real_time": 4.8222647567129464e+01,
+      "cpu_time": 4.8221611142869321e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=319 num_sets=105187"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33555045,
+      "real_time": 5.5063014961990184e+01,
+      "cpu_time": 5.5061870964578596e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.088 size=5119 num_sets=6555"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33586790,
+      "real_time": 2.7196243090293727e+01,
+      "cpu_time": 2.7195309733412596e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=81919 num_sets=410"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 34078694,
+      "real_time": 1.8864697527891369e+01,
+      "cpu_time": 1.8864373793175659e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.084 size=1310719 num_sets=26"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971750,
+      "real_time": 9.3683816250709199e+01,
+      "cpu_time": 9.3683084387314622e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.047 size=25 num_sets=83887"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20974800,
+      "real_time": 9.0201400220536215e+01,
+      "cpu_time": 9.0197874640042315e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=385 num_sets=5448"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 21015900,
+      "real_time": 8.5624555711262161e+01,
+      "cpu_time": 8.5623696582103136e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=6145 num_sets=342"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21627100,
+      "real_time": 4.8282653329390826e+01,
+      "cpu_time": 4.8276898705845490e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=98305 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 22020110,
+      "real_time": 1.0798463789747744e+02,
+      "cpu_time": 1.0794655526247445e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.046 size=1572865 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971630,
+      "real_time": 9.4221030950834916e+01,
+      "cpu_time": 9.4218946023732613e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.087 size=23 num_sets=91181"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20973080,
+      "real_time": 9.0957813115866912e+01,
+      "cpu_time": 9.0951444804483927e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.104 size=383 num_sets=5476"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 21009060,
+      "real_time": 8.8239497960067681e+01,
+      "cpu_time": 8.8239043298432165e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.106 size=6143 num_sets=342"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21626660,
+      "real_time": 8.5822171109839488e+01,
+      "cpu_time": 8.5819464817888360e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.103 size=98303 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14ValueSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 22020082,
+      "real_time": 7.3388570869260647e+01,
+      "cpu_time": 7.3387856548421240e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.101 size=1572863 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33554450,
+      "real_time": 1.3341995190167862e+02,
+      "cpu_time": 1.3341631381233719e+02,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.047 size=25 num_sets=1342178"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33554675,
+      "real_time": 1.0622902898438434e+02,
+      "cpu_time": 1.0622719591232655e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=385 num_sets=87155"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33557845,
+      "real_time": 1.2466363884385329e+02,
+      "cpu_time": 1.2466399540856440e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=6145 num_sets=5461"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33620310,
+      "real_time": 1.1576605918935061e+02,
+      "cpu_time": 1.1576411793944921e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=98305 num_sets=342"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 34603030,
+      "real_time": 3.4341768442242579e+02,
+      "cpu_time": 3.4340994803059397e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.046 size=1572865 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33554447,
+      "real_time": 1.0365880227675507e+02,
+      "cpu_time": 1.0365869182706916e+02,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.087 size=23 num_sets=1458889"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33554630,
+      "real_time": 1.2194839431778107e+02,
+      "cpu_time": 1.2194829983223347e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.104 size=383 num_sets=87610"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33559209,
+      "real_time": 1.3682355570106381e+02,
+      "cpu_time": 1.3682231726616433e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.106 size=6143 num_sets=5463"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33619626,
+      "real_time": 1.3461747083223588e+02,
+      "cpu_time": 1.3461740380454415e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.103 size=98303 num_sets=342"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 34602986,
+      "real_time": 2.9844118863398796e+02,
+      "cpu_time": 2.9843417082557454e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.102 size=1572863 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971750,
+      "real_time": 2.7551524468913885e+02,
+      "cpu_time": 2.7550853614979451e+02,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.047 size=25 num_sets=83887"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20974800,
+      "real_time": 2.5256772853099756e+02,
+      "cpu_time": 2.5255374578068253e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=385 num_sets=5448"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 21015900,
+      "real_time": 2.3045552403168833e+02,
+      "cpu_time": 2.3044902150277028e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=6145 num_sets=342"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21627100,
+      "real_time": 1.7636878544984052e+02,
+      "cpu_time": 1.7636213024398631e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.047 size=98305 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 22020110,
+      "real_time": 1.4626429275357759e+02,
+      "cpu_time": 1.4626101804215659e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.046 size=1572865 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971630,
+      "real_time": 2.7251223025467522e+02,
+      "cpu_time": 2.7250684291113430e+02,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.087 size=23 num_sets=91181"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20973080,
+      "real_time": 2.3187428519193725e+02,
+      "cpu_time": 2.3184802127298423e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.104 size=383 num_sets=5476"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 21009060,
+      "real_time": 2.4187741464530544e+02,
+      "cpu_time": 2.4187230352046109e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.107 size=6143 num_sets=342"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21626660,
+      "real_time": 1.8982394821835985e+02,
+      "cpu_time": 1.8982050668020764e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.103 size=98303 num_sets=22"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14NodeSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 22020082,
+      "real_time": 1.9669550478554893e+02,
+      "cpu_time": 1.9669224074636762e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.102 size=1572863 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33554451,
+      "real_time": 6.2703065872549644e+01,
+      "cpu_time": 6.2697060488302490e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.039 size=21 num_sets=1597831"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33554451,
+      "real_time": 1.5626491423128257e+02,
+      "cpu_time": 1.5624092884130283e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=321 num_sets=104531"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33557913,
+      "real_time": 2.1780212483624135e+02,
+      "cpu_time": 2.1780098598498952e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=5121 num_sets=6553"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33587610,
+      "real_time": 1.3704048481250263e+02,
+      "cpu_time": 1.3704007197894410e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=81921 num_sets=410"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 34078746,
+      "real_time": 1.2903551878082274e+02,
+      "cpu_time": 1.2903379070927474e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.038 size=1310721 num_sets=26"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33554437,
+      "real_time": 3.3886140395766013e+01,
+      "cpu_time": 3.3886245297460526e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.071 size=19 num_sets=1766023"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33554653,
+      "real_time": 1.8022312491270901e+02,
+      "cpu_time": 1.8022008825427031e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.085 size=319 num_sets=105187"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33555045,
+      "real_time": 1.6387695221879602e+02,
+      "cpu_time": 1.6387752211329357e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=5119 num_sets=6555"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33586790,
+      "real_time": 1.3558402140062159e+02,
+      "cpu_time": 1.3558446871526354e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=81919 num_sets=410"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 34078694,
+      "real_time": 1.4033815487781999e+02,
+      "cpu_time": 1.4033350248105623e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=1310719 num_sets=26"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971650,
+      "real_time": 1.3423084293839349e+02,
+      "cpu_time": 1.3422536476626883e+02,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.039 size=21 num_sets=99865"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20974140,
+      "real_time": 1.3970428402601846e+02,
+      "cpu_time": 1.3970057370648391e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=321 num_sets=6534"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20996100,
+      "real_time": 1.1475053361059697e+02,
+      "cpu_time": 1.1474772057672176e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=5121 num_sets=410"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21299460,
+      "real_time": 1.1382104976687111e+02,
+      "cpu_time": 1.1381941246393090e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.039 size=81921 num_sets=26"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 20971536,
+      "real_time": 1.0831055000610411e+02,
+      "cpu_time": 1.0830816893914107e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.038 size=1310721 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971630,
+      "real_time": 1.1183976084913421e+02,
+      "cpu_time": 1.1183835376653192e+02,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.071 size=19 num_sets=110377"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20974250,
+      "real_time": 1.2495379704437971e+02,
+      "cpu_time": 1.2495046483184392e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.085 size=319 num_sets=6575"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20987900,
+      "real_time": 1.1146978209870795e+02,
+      "cpu_time": 1.1146903101310157e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=5119 num_sets=410"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21298940,
+      "real_time": 1.1403990482624384e+02,
+      "cpu_time": 1.1403849346489682e+02,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.086 size=81919 num_sets=26"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, folly::F14VectorSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 20971504,
+      "real_time": 8.5802045738066894e+01,
+      "cpu_time": 8.5800345077711370e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.085 size=1310719 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33554447,
+      "real_time": 4.4348831876652326e+01,
+      "cpu_time": 4.4348446690204504e+01,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=1.551 size=17 num_sets=1973791"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33554434,
+      "real_time": 2.9250896848692012e+01,
+      "cpu_time": 2.9250400587865833e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.339 size=257 num_sets=130562"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33558527,
+      "real_time": 2.9069480774874140e+01,
+      "cpu_time": 2.9068753047441593e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.325 size=4097 num_sets=8191"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554944,
+      "real_time": 2.3894867852632839e+01,
+      "cpu_time": 2.3894919419320239e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.324 size=65537 num_sets=512"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554464,
+      "real_time": 2.2747940042387221e+01,
+      "cpu_time": 2.2747940154818878e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.322 size=1048577 num_sets=32"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33554462,
+      "real_time": 3.9511292217247771e+01,
+      "cpu_time": 3.9511373301132103e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.879 size=31 num_sets=1082402"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33554815,
+      "real_time": 2.5573704348360312e+01,
+      "cpu_time": 2.5573743201982190e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.869 size=511 num_sets=65665"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33558527,
+      "real_time": 2.9308257942448403e+01,
+      "cpu_time": 2.9307544428255948e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.869 size=8191 num_sets=4097"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33685247,
+      "real_time": 2.0387091509355656e+01,
+      "cpu_time": 2.0387199743534524e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.869 size=131071 num_sets=257"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 35651567,
+      "real_time": 1.3744310549373603e+01,
+      "cpu_time": 1.3744061291889592e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.866 size=2097151 num_sets=17"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20971540,
+      "real_time": 1.4112356622828466e+02,
+      "cpu_time": 1.4112248623610171e+02,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=1.552 size=17 num_sets=123362"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20973770,
+      "real_time": 1.1185840516700969e+02,
+      "cpu_time": 1.1185701101906088e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.339 size=257 num_sets=8161"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20976640,
+      "real_time": 1.0480315915281842e+02,
+      "cpu_time": 1.0480306326466867e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.324 size=4097 num_sets=512"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971840,
+      "real_time": 9.8495841042676801e+01,
+      "cpu_time": 9.8494774707340085e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.324 size=65537 num_sets=32"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 20971540,
+      "real_time": 1.6769968092752549e+02,
+      "cpu_time": 1.6769929938387423e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=1.324 size=1048577 num_sets=2"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20971810,
+      "real_time": 9.9611211659134625e+01,
+      "cpu_time": 9.9610180427906471e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=1.881 size=31 num_sets=67651"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20976550,
+      "real_time": 8.2509430623491014e+01,
+      "cpu_time": 8.2507278937716663e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.867 size=511 num_sets=4105"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 21050870,
+      "real_time": 7.2023797000798083e+01,
+      "cpu_time": 7.2023468673732225e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.869 size=8191 num_sets=257"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 20053863,
+      "real_time": 5.0905555832436825e+01,
+      "cpu_time": 5.0903137515219051e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.868 size=131071 num_sets=17"
+    },
+    {
+      "name": "BM<InsertManyOrdered_Cold, google::dense_hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 20971510,
+      "real_time": 8.9270335414190058e+01,
+      "cpu_time": 8.9270234999760518e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=1.867 size=2097151 num_sets=2"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33572864,
+      "real_time": 1.4883158824492975e+01,
+      "cpu_time": 1.4882633962951704e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=194 num_sets=1352"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33596160,
+      "real_time": 1.5062062452919221e+01,
+      "cpu_time": 1.5062179010948414e+01,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=0.000 size=390 num_sets=673"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33860608,
+      "real_time": 1.9684085764886966e+01,
+      "cpu_time": 1.9684113971018327e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=6152 num_sets=43"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 37754112,
+      "real_time": 2.2297786122582448e+01,
+      "cpu_time": 2.2297878043041454e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=98318 num_sets=3"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 100663680,
+      "real_time": 2.2806205559397736e+01,
+      "cpu_time": 2.2802232026484397e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1572870 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33570816,
+      "real_time": 1.2198283203880690e+01,
+      "cpu_time": 1.2198038022043708e+01,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=0.000 size=192 num_sets=1366"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33572864,
+      "real_time": 1.2326779766970089e+01,
+      "cpu_time": 1.2326878338412211e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=388 num_sets=676"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33849600,
+      "real_time": 1.4776069199707585e+01,
+      "cpu_time": 1.4775358674812640e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=6150 num_sets=43"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 37753344,
+      "real_time": 1.6301946784820867e+01,
+      "cpu_time": 1.6301657331331970e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=98316 num_sets=3"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 100663552,
+      "real_time": 1.6767723792065848e+01,
+      "cpu_time": 1.6767661794814718e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1572868 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33572864,
+      "real_time": 1.6397516714303435e+01,
+      "cpu_time": 1.6397263635304412e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=194 num_sets=1352"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33596160,
+      "real_time": 1.6963036350010871e+01,
+      "cpu_time": 1.6963152753191721e+01,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=0.000 size=390 num_sets=673"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33860608,
+      "real_time": 2.2108391626700918e+01,
+      "cpu_time": 2.2108086570679816e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=6152 num_sets=43"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 37754112,
+      "real_time": 2.3835743692232487e+01,
+      "cpu_time": 2.3835755321174453e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=98318 num_sets=3"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 100663680,
+      "real_time": 2.4007259785704189e+01,
+      "cpu_time": 2.4007111472580792e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1572870 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33570816,
+      "real_time": 1.3358920952146114e+01,
+      "cpu_time": 1.3358324295698097e+01,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=0.000 size=192 num_sets=1366"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33572864,
+      "real_time": 1.3651789659106447e+01,
+      "cpu_time": 1.3651892165071150e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=388 num_sets=676"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33849600,
+      "real_time": 1.6707824858313675e+01,
+      "cpu_time": 1.6707736664550968e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=6150 num_sets=43"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 37753344,
+      "real_time": 1.8645782210950809e+01,
+      "cpu_time": 1.8645011048571398e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=98316 num_sets=3"
+    },
+    {
+      "name": "BM<Iterate_Hot, __gnu_cxx::hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 100663552,
+      "real_time": 2.0055470092005979e+01,
+      "cpu_time": 2.0055373507980356e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1572868 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556096,
+      "real_time": 7.7708915884961682e-01,
+      "cpu_time": 7.7709629872579011e-01,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=0.000 size=17 num_sets=15421"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33586816,
+      "real_time": 1.4347713586958322e+00,
+      "cpu_time": 1.4347821776450345e+00,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=0.000 size=257 num_sets=1021"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33956992,
+      "real_time": 5.0591202887355529e+00,
+      "cpu_time": 5.0591565943412791e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=4349 num_sets=61"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 34461184,
+      "real_time": 1.2219390256312742e+01,
+      "cpu_time": 1.2219270933915848e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=67307 num_sets=4"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67604672,
+      "real_time": 2.4417108076985482e+01,
+      "cpu_time": 2.4415942199992418e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=1056323 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33555200,
+      "real_time": 1.5099042816605932e+00,
+      "cpu_time": 1.5099155123285879e+00,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=35 num_sets=7490"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33599104,
+      "real_time": 1.3369110669454394e+00,
+      "cpu_time": 1.3369218714892519e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=539 num_sets=487"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33941376,
+      "real_time": 4.6718172364616386e+00,
+      "cpu_time": 4.6717220303751077e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=4347 num_sets=61"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 34460160,
+      "real_time": 9.1482707441194080e+00,
+      "cpu_time": 9.1481508501543267e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=67305 num_sets=4"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 67604544,
+      "real_time": 1.4172633318338823e+01,
+      "cpu_time": 1.4172246114108004e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1056321 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556096,
+      "real_time": 2.8482398393054948e+00,
+      "cpu_time": 2.8480867977179258e+00,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=0.000 size=17 num_sets=15421"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33586816,
+      "real_time": 3.1516543403169899e+00,
+      "cpu_time": 3.1511479087313869e+00,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=0.000 size=257 num_sets=1021"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33956992,
+      "real_time": 9.8172350318484813e+00,
+      "cpu_time": 9.8173161509634319e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=4349 num_sets=61"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 34461184,
+      "real_time": 1.4575654219735872e+01,
+      "cpu_time": 1.4575769132000381e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=67307 num_sets=4"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67604672,
+      "real_time": 5.7672490953966090e+01,
+      "cpu_time": 5.7669613898885522e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=1056323 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33555200,
+      "real_time": 3.7373834590340715e+00,
+      "cpu_time": 3.7374124129661670e+00,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=35 num_sets=7490"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33599104,
+      "real_time": 4.9933632608000327e+00,
+      "cpu_time": 4.9932494925928470e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=539 num_sets=487"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33941376,
+      "real_time": 8.2392547033362202e+00,
+      "cpu_time": 8.2390488234666606e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=4347 num_sets=61"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 34460160,
+      "real_time": 1.2430862831012002e+01,
+      "cpu_time": 1.2430960564288789e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=67305 num_sets=4"
+    },
+    {
+      "name": "BM<Iterate_Hot, std::unordered_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 67604544,
+      "real_time": 4.4093187150127299e+01,
+      "cpu_time": 4.4091745223532563e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1056321 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556992,
+      "real_time": 1.6978899640586349e+00,
+      "cpu_time": 1.6978987269962360e+00,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.000 size=21 num_sets=12484"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33568896,
+      "real_time": 1.9273405993594370e+00,
+      "cpu_time": 1.9273623713791777e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=321 num_sets=817"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34085376,
+      "real_time": 2.0592744801535212e+00,
+      "cpu_time": 2.0592952825240571e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=5121 num_sets=52"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971776,
+      "real_time": 2.9193855122420600e+00,
+      "cpu_time": 2.9194253266955834e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=81921 num_sets=4"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 83886144,
+      "real_time": 2.7745137891262339e+00,
+      "cpu_time": 2.7745246938498931e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33556736,
+      "real_time": 1.2340356269576720e+00,
+      "cpu_time": 1.2340480015710422e+00,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=19 num_sets=13798"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33563904,
+      "real_time": 1.3407069999427959e+00,
+      "cpu_time": 1.3407129575782704e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=319 num_sets=822"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34072064,
+      "real_time": 1.4395215415412883e+00,
+      "cpu_time": 1.4395345406818412e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=5119 num_sets=52"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 20971264,
+      "real_time": 1.6607803360023723e+00,
+      "cpu_time": 1.6608044226716545e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=81919 num_sets=4"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 83886016,
+      "real_time": 1.7137081727583872e+00,
+      "cpu_time": 1.7137182078160911e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1310719 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33555200,
+      "real_time": 2.9566640756568132e+00,
+      "cpu_time": 2.9566950874659508e+00,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.000 size=25 num_sets=10486"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33559680,
+      "real_time": 3.4198970569340190e+00,
+      "cpu_time": 3.4196594544351111e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=385 num_sets=681"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33822080,
+      "real_time": 5.5273546298129883e+00,
+      "cpu_time": 5.5273957426839759e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=6145 num_sets=43"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 37749120,
+      "real_time": 5.9823931822781562e+00,
+      "cpu_time": 5.9824386369677551e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=98305 num_sets=3"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 100663360,
+      "real_time": 1.5400089774833434e+01,
+      "cpu_time": 1.5399759962314347e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33555712,
+      "real_time": 2.8231912317798904e+00,
+      "cpu_time": 2.8231873309692777e+00,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.000 size=23 num_sets=11398"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33581440,
+      "real_time": 2.9210419332326119e+00,
+      "cpu_time": 2.9210691084081488e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=383 num_sets=685"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33811072,
+      "real_time": 4.5194577845662991e+00,
+      "cpu_time": 4.5194883498284035e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=6143 num_sets=43"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 37748352,
+      "real_time": 4.5352919932500466e+00,
+      "cpu_time": 4.5350405495596533e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=98303 num_sets=3"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14ValueSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 100663232,
+      "real_time": 1.1525240243730462e+01,
+      "cpu_time": 1.1525151099848364e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1572863 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33555200,
+      "real_time": 1.6144298311182954e+00,
+      "cpu_time": 1.6144365106265779e+00,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.000 size=25 num_sets=10486"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33559680,
+      "real_time": 1.6985141315042267e+00,
+      "cpu_time": 1.6985283232799677e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=385 num_sets=681"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33822080,
+      "real_time": 2.5595078340286741e+00,
+      "cpu_time": 2.5595234828830233e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=6145 num_sets=43"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 37749120,
+      "real_time": 3.5080180139775909e+00,
+      "cpu_time": 3.5080442405131667e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=98305 num_sets=3"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 100663360,
+      "real_time": 1.4761617794691034e+01,
+      "cpu_time": 1.4761369131725617e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33555712,
+      "real_time": 1.3555643531709505e+00,
+      "cpu_time": 1.3555675409289951e+00,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.000 size=23 num_sets=11398"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33581440,
+      "real_time": 1.5840453196070809e+00,
+      "cpu_time": 1.5840640842402869e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=383 num_sets=685"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33811072,
+      "real_time": 2.2177160896637265e+00,
+      "cpu_time": 2.2177351548765603e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=6143 num_sets=43"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 37748352,
+      "real_time": 2.9976555554830546e+00,
+      "cpu_time": 2.9975606087645579e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=98303 num_sets=3"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 100663232,
+      "real_time": 1.2875895209529636e+01,
+      "cpu_time": 1.2875858744534785e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1572863 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33555200,
+      "real_time": 3.3499049521938615e+00,
+      "cpu_time": 3.3499237972020657e+00,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.000 size=25 num_sets=10486"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33559680,
+      "real_time": 3.9671993702107300e+00,
+      "cpu_time": 3.9672297828544831e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=385 num_sets=681"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33822080,
+      "real_time": 7.3191271303396936e+00,
+      "cpu_time": 7.3191939407987299e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=6145 num_sets=43"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 37749120,
+      "real_time": 9.0745868694664420e+00,
+      "cpu_time": 9.0733177356002557e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=98305 num_sets=3"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 100663360,
+      "real_time": 3.2054755638851049e+01,
+      "cpu_time": 3.2053792194102776e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1572865 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33555712,
+      "real_time": 2.8488408460856944e+00,
+      "cpu_time": 2.8488433503887611e+00,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.000 size=23 num_sets=11398"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33581440,
+      "real_time": 3.1356449517601952e+00,
+      "cpu_time": 3.1356597275174427e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=383 num_sets=685"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33811072,
+      "real_time": 6.9612280518784910e+00,
+      "cpu_time": 6.9612667116826934e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=6143 num_sets=43"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 37748352,
+      "real_time": 8.2394426407875194e+00,
+      "cpu_time": 8.2378194417361019e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=98303 num_sets=3"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14NodeSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 100663232,
+      "real_time": 3.0332700244581243e+01,
+      "cpu_time": 3.0332404944042480e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1572863 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556992,
+      "real_time": 7.0992724384853167e-01,
+      "cpu_time": 7.0906599734129894e-01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.000 size=21 num_sets=12484"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33568896,
+      "real_time": 3.7928053878154472e-01,
+      "cpu_time": 3.7927928880157630e-01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=321 num_sets=817"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34085376,
+      "real_time": 3.3463568783274833e-01,
+      "cpu_time": 3.3463832116242370e-01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=5121 num_sets=52"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971776,
+      "real_time": 3.7377502237775057e-01,
+      "cpu_time": 3.7376948902435270e-01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=81921 num_sets=4"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 83886144,
+      "real_time": 3.7825855787898355e-01,
+      "cpu_time": 3.7825544823773705e-01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33556736,
+      "real_time": 4.1816831921917441e-01,
+      "cpu_time": 4.1817636848813489e-01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=19 num_sets=13798"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33563904,
+      "real_time": 3.5190353329253371e-01,
+      "cpu_time": 3.5191496200247757e-01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=319 num_sets=822"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34072064,
+      "real_time": 3.2363344009471412e-01,
+      "cpu_time": 3.2363175884598505e-01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=5119 num_sets=52"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 20971264,
+      "real_time": 3.5696965930188856e-01,
+      "cpu_time": 3.5696780130362898e-01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=81919 num_sets=4"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 83886016,
+      "real_time": 3.6606052806185052e-01,
+      "cpu_time": 3.6605368168853669e-01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1310719 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556992,
+      "real_time": 2.6584420367895532e+00,
+      "cpu_time": 2.6584659018364780e+00,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.000 size=21 num_sets=12484"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33568896,
+      "real_time": 2.6466397987459716e+00,
+      "cpu_time": 2.6466621958640699e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=321 num_sets=817"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 34085376,
+      "real_time": 3.0283756829328063e+00,
+      "cpu_time": 3.0283805289104704e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=5121 num_sets=52"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971776,
+      "real_time": 2.9357334799462760e+00,
+      "cpu_time": 2.9357520794243408e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=81921 num_sets=4"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 83886144,
+      "real_time": 6.0121390848982603e+00,
+      "cpu_time": 6.0121829893715306e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1310721 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33556736,
+      "real_time": 2.6093813956332688e+00,
+      "cpu_time": 2.6094020586741768e+00,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=19 num_sets=13798"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33563904,
+      "real_time": 2.5592351389120034e+00,
+      "cpu_time": 2.5592445682128182e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=319 num_sets=822"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34072064,
+      "real_time": 2.9787291801115345e+00,
+      "cpu_time": 2.9787519770157416e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=5119 num_sets=52"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 20971264,
+      "real_time": 2.9454686531708396e+00,
+      "cpu_time": 2.9454704304167358e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=81919 num_sets=4"
+    },
+    {
+      "name": "BM<Iterate_Hot, folly::F14VectorSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 83886016,
+      "real_time": 6.0864284529691224e+00,
+      "cpu_time": 6.0864658777051055e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1310719 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556096,
+      "real_time": 3.3621285995080736e+00,
+      "cpu_time": 3.3621497864241374e+00,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=3.765 size=17 num_sets=15421"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33586816,
+      "real_time": 4.0097799444781757e+00,
+      "cpu_time": 4.0098072707911365e+00,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=3.984 size=257 num_sets=1021"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33562624,
+      "real_time": 1.0856673551538323e+01,
+      "cpu_time": 1.0856757504993798e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=3.999 size=4097 num_sets=64"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554944,
+      "real_time": 1.1108114573983075e+01,
+      "cpu_time": 1.1107879542270858e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=4.000 size=65537 num_sets=4"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67108928,
+      "real_time": 1.1015277732116498e+01,
+      "cpu_time": 1.1015354797485790e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=4.000 size=1048577 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33557376,
+      "real_time": 2.5185748637537628e+00,
+      "cpu_time": 2.5174116116799690e+00,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=2.065 size=31 num_sets=8457"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33619712,
+      "real_time": 2.6918907926821265e+00,
+      "cpu_time": 2.6919031310762662e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.004 size=511 num_sets=514"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34598784,
+      "real_time": 7.6592317494214477e+00,
+      "cpu_time": 7.6592811180557492e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.000 size=8191 num_sets=33"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 25165632,
+      "real_time": 8.3728057866382528e+00,
+      "cpu_time": 8.3728573555901438e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.000 size=131071 num_sets=3"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 134217664,
+      "real_time": 8.1640226872415287e+00,
+      "cpu_time": 8.1638414672478721e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.000 size=2097151 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 33556096,
+      "real_time": 6.5359727112678883e+00,
+      "cpu_time": 6.5360232310659132e+00,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=3.765 size=17 num_sets=15421"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 33586816,
+      "real_time": 1.0839895274806615e+01,
+      "cpu_time": 1.0839979115637874e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=3.984 size=257 num_sets=1021"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33562624,
+      "real_time": 1.4610982436140281e+01,
+      "cpu_time": 1.4610850063411712e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=3.999 size=4097 num_sets=64"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554944,
+      "real_time": 1.5162523245701234e+01,
+      "cpu_time": 1.5162629238778266e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=4.000 size=65537 num_sets=4"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 67108928,
+      "real_time": 2.4972750255004421e+01,
+      "cpu_time": 2.4971902948589175e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=4.000 size=1048577 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 33557376,
+      "real_time": 3.4940573476066548e+00,
+      "cpu_time": 3.4940924165184932e+00,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=2.065 size=31 num_sets=8457"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 33619712,
+      "real_time": 4.7257562716359596e+00,
+      "cpu_time": 4.7257904826723225e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.004 size=511 num_sets=514"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 34598784,
+      "real_time": 1.0616263529119379e+01,
+      "cpu_time": 1.0615584380037150e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.000 size=8191 num_sets=33"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 25165632,
+      "real_time": 1.0853395719898039e+01,
+      "cpu_time": 1.0853142690767692e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.000 size=131071 num_sets=3"
+    },
+    {
+      "name": "BM<Iterate_Hot, google::dense_hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 134217664,
+      "real_time": 1.6064277574339904e+01,
+      "cpu_time": 1.6064192795069943e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.000 size=2097151 num_sets=1"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 33208512,
+      "real_time": 1.1594646299573630e+02,
+      "cpu_time": 1.1594270854408114e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=194 num_sets=172961"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33038592,
+      "real_time": 1.3549952186099733e+02,
+      "cpu_time": 1.3549621170293531e+02,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=0.000 size=390 num_sets=86038"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33515520,
+      "real_time": 1.1633884268700439e+02,
+      "cpu_time": 1.1633781615204185e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=6152 num_sets=5455"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33619968,
+      "real_time": 8.9864579510927697e+01,
+      "cpu_time": 8.9863622267600419e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=98318 num_sets=342"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 34603008,
+      "real_time": 1.2691459067520390e+02,
+      "cpu_time": 1.2691076385613393e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1572870 num_sets=22"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 33554496,
+      "real_time": 6.2857311369192530e+01,
+      "cpu_time": 6.2853927622679016e+01,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=0.000 size=192 num_sets=174763"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 33208704,
+      "real_time": 8.5874407865387596e+01,
+      "cpu_time": 8.5871968535693199e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=388 num_sets=86481"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33527808,
+      "real_time": 6.5642270047876835e+01,
+      "cpu_time": 6.5642126380582241e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=6150 num_sets=5457"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33619968,
+      "real_time": 5.2795936961678272e+01,
+      "cpu_time": 5.2795988384049075e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=98316 num_sets=342"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 34603008,
+      "real_time": 5.6379025353993654e+01,
+      "cpu_time": 5.6377000722005917e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1572868 num_sets=22"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20757120,
+      "real_time": 1.1403972420092447e+02,
+      "cpu_time": 1.1403760030291738e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=194 num_sets=10811"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20651520,
+      "real_time": 1.1378691871251642e+02,
+      "cpu_time": 1.1377832517895706e+02,
+      "time_unit": "ns",
+      "label": "lf=0.51 cmp=0.000 size=390 num_sets=5378"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20951040,
+      "real_time": 1.0921459604975998e+02,
+      "cpu_time": 1.0921095253498801e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=6152 num_sets=341"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21626880,
+      "real_time": 1.0205201926344836e+02,
+      "cpu_time": 1.0204995510214856e+02,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=98318 num_sets=22"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 22020096,
+      "real_time": 9.0400849980401944e+01,
+      "cpu_time": 9.0400581950260204e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1572870 num_sets=2"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20972160,
+      "real_time": 6.4577428148439552e+01,
+      "cpu_time": 6.4577658953640267e+01,
+      "time_unit": "ns",
+      "label": "lf=0.99 cmp=0.000 size=192 num_sets=10923"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20759040,
+      "real_time": 6.3837884309362700e+01,
+      "cpu_time": 6.3837286165392364e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=388 num_sets=5406"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 21012480,
+      "real_time": 6.3618533876061903e+01,
+      "cpu_time": 6.3616723632791917e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=6150 num_sets=342"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21626880,
+      "real_time": 6.4535737637373984e+01,
+      "cpu_time": 6.4534584461502689e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=98316 num_sets=22"
+    },
+    {
+      "name": "BM<Iterate_Cold, __gnu_cxx::hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 22020096,
+      "real_time": 6.1546903192980345e+01,
+      "cpu_time": 6.1547317504835668e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1572868 num_sets=2"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 31580656,
+      "real_time": 1.3602954454768975e+01,
+      "cpu_time": 1.3603038866565315e+01,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=0.000 size=17 num_sets=1973791"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33423872,
+      "real_time": 1.4781537723187729e+01,
+      "cpu_time": 1.4781398486645584e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=0.000 size=257 num_sets=130562"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33456576,
+      "real_time": 1.6956238948876919e+01,
+      "cpu_time": 1.6956366096743899e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=4349 num_sets=7716"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33580704,
+      "real_time": 1.5831961040652356e+01,
+      "cpu_time": 1.5831363660492260e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=67307 num_sets=499"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33802240,
+      "real_time": 1.6214210349334007e+01,
+      "cpu_time": 1.6213219715591816e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=1056323 num_sets=32"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 30678368,
+      "real_time": 1.5147099776833819e+01,
+      "cpu_time": 1.5147167802414899e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=35 num_sets=958699"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 32870112,
+      "real_time": 1.4935041613329750e+01,
+      "cpu_time": 1.4935160366923885e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=539 num_sets=62254"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33469584,
+      "real_time": 1.7378864647150866e+01,
+      "cpu_time": 1.7378150741294505e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=4347 num_sets=7719"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33580704,
+      "real_time": 1.6089167973095233e+01,
+      "cpu_time": 1.6088991553022439e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=67305 num_sets=499"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 33802240,
+      "real_time": 1.7621583776180039e+01,
+      "cpu_time": 1.7621350596922724e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1056321 num_sets=32"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 21711712,
+      "real_time": 2.9771992576970185e+01,
+      "cpu_time": 2.9771186537490134e+01,
+      "time_unit": "ns",
+      "label": "lf=0.46 cmp=0.000 size=17 num_sets=123362"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20892160,
+      "real_time": 3.2306029240504564e+01,
+      "cpu_time": 3.2305565054018750e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=0.000 size=257 num_sets=8161"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20942880,
+      "real_time": 3.2869256928079402e+01,
+      "cpu_time": 3.2869497795862138e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=4349 num_sets=483"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21534720,
+      "real_time": 3.3363158745080923e+01,
+      "cpu_time": 3.3363091695676907e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=67307 num_sets=32"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 21126400,
+      "real_time": 3.7526425738220539e+01,
+      "cpu_time": 3.7525629733445101e+01,
+      "time_unit": "ns",
+      "label": "lf=0.49 cmp=0.000 size=1056323 num_sets=2"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 21091488,
+      "real_time": 3.1382680750808145e+01,
+      "cpu_time": 3.1382682815030041e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=35 num_sets=59919"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20544480,
+      "real_time": 3.2051091817925936e+01,
+      "cpu_time": 3.2050503152202886e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=539 num_sets=3891"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20942880,
+      "real_time": 3.2084985885467987e+01,
+      "cpu_time": 3.2084229103197302e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=4347 num_sets=483"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21534720,
+      "real_time": 3.1342326042995644e+01,
+      "cpu_time": 3.1342302059221943e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=67305 num_sets=32"
+    },
+    {
+      "name": "BM<Iterate_Cold, std::unordered_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 21126400,
+      "real_time": 3.0683989472116206e+01,
+      "cpu_time": 3.0684215720546813e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1056321 num_sets=2"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 25565296,
+      "real_time": 1.7619856921714280e+01,
+      "cpu_time": 1.7619765677665864e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.000 size=21 num_sets=1597831"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33449920,
+      "real_time": 2.7030794218013924e+01,
+      "cpu_time": 2.7029706707828300e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=321 num_sets=104531"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33551360,
+      "real_time": 2.5793144275591644e+01,
+      "cpu_time": 2.5793301910901743e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=5121 num_sets=6553"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33587200,
+      "real_time": 2.3802610330011060e+01,
+      "cpu_time": 2.3802249071075014e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=81921 num_sets=410"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 34078720,
+      "real_time": 1.8118897479815551e+01,
+      "cpu_time": 1.8118380796004431e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1310721 num_sets=26"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 28256368,
+      "real_time": 1.3760114995374360e+01,
+      "cpu_time": 1.3759914579226566e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=19 num_sets=1766023"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 31976848,
+      "real_time": 3.1373341054956509e+01,
+      "cpu_time": 3.1372533903284310e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=319 num_sets=105187"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33456720,
+      "real_time": 2.3547197530200577e+01,
+      "cpu_time": 2.3547356166411234e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=5119 num_sets=6555"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33580640,
+      "real_time": 2.1101580380942448e+01,
+      "cpu_time": 2.1101085893547332e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=81919 num_sets=410"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 34078304,
+      "real_time": 1.1667882052531560e+01,
+      "cpu_time": 1.1667962378628319e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1310719 num_sets=26"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20132880,
+      "real_time": 3.2214718784403502e+01,
+      "cpu_time": 3.2214957720877955e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.000 size=25 num_sets=83887"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20920320,
+      "real_time": 3.7210428202000543e+01,
+      "cpu_time": 3.7210279192702686e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=385 num_sets=5448"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 21012480,
+      "real_time": 3.5606080041671824e+01,
+      "cpu_time": 3.5606331094651395e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=6145 num_sets=342"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21626880,
+      "real_time": 3.5484735042590536e+01,
+      "cpu_time": 3.5484989050684554e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=98305 num_sets=22"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 22020096,
+      "real_time": 3.8242887967498973e+01,
+      "cpu_time": 3.8240440504879494e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1572865 num_sets=2"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20424544,
+      "real_time": 2.9994123765156555e+01,
+      "cpu_time": 2.9992659713706271e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.000 size=23 num_sets=91181"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20151680,
+      "real_time": 3.3582497628179539e+01,
+      "cpu_time": 3.3580924121486170e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=383 num_sets=5476"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20957760,
+      "real_time": 3.0781911114155413e+01,
+      "cpu_time": 3.0776264018669359e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=6143 num_sets=342"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21623360,
+      "real_time": 3.0712295922486017e+01,
+      "cpu_time": 3.0711274381063344e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=98303 num_sets=22"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14ValueSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 22019872,
+      "real_time": 3.4364773179563556e+01,
+      "cpu_time": 3.4361229756456048e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1572863 num_sets=2"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 21474848,
+      "real_time": 3.5651029655080798e+01,
+      "cpu_time": 3.5649387786185436e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.000 size=25 num_sets=1342178"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33467520,
+      "real_time": 4.1359178357874512e+01,
+      "cpu_time": 4.1357909041331183e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=385 num_sets=87155"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33552384,
+      "real_time": 4.7041766647016843e+01,
+      "cpu_time": 4.7037103086316982e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=6145 num_sets=5461"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33619968,
+      "real_time": 4.3368863044433716e+01,
+      "cpu_time": 4.3366579527977869e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=98305 num_sets=342"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 34603008,
+      "real_time": 3.9225493641093969e+01,
+      "cpu_time": 3.9225382920475681e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1572865 num_sets=22"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 23342224,
+      "real_time": 3.2964376924558749e+01,
+      "cpu_time": 3.2956022956515952e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.000 size=23 num_sets=1458889"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 32240480,
+      "real_time": 4.1314174338996189e+01,
+      "cpu_time": 4.1314110739068866e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=383 num_sets=87610"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33477264,
+      "real_time": 4.4737661128462825e+01,
+      "cpu_time": 4.4737641672270477e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=6143 num_sets=5463"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33614496,
+      "real_time": 4.5292875345327907e+01,
+      "cpu_time": 4.5292055338291973e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=98303 num_sets=342"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 34602656,
+      "real_time": 3.8953758060263588e+01,
+      "cpu_time": 3.8953334044640215e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1572863 num_sets=22"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20132880,
+      "real_time": 4.6264978857090917e+01,
+      "cpu_time": 4.6264734305323955e+01,
+      "time_unit": "ns",
+      "label": "lf=0.52 cmp=0.000 size=25 num_sets=83887"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20920320,
+      "real_time": 6.0537631240068436e+01,
+      "cpu_time": 6.0537462667890956e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=385 num_sets=5448"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 21012480,
+      "real_time": 5.1918839418545339e+01,
+      "cpu_time": 5.1918150689506191e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=6145 num_sets=342"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21626880,
+      "real_time": 5.3313631338603571e+01,
+      "cpu_time": 5.3311437156057472e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=98305 num_sets=22"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 22020096,
+      "real_time": 5.9905763312902614e+01,
+      "cpu_time": 5.9905777386218539e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1572865 num_sets=2"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20424544,
+      "real_time": 4.3351430368358990e+01,
+      "cpu_time": 4.3350180498542088e+01,
+      "time_unit": "ns",
+      "label": "lf=0.96 cmp=0.000 size=23 num_sets=91181"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20151680,
+      "real_time": 5.2662143279610596e+01,
+      "cpu_time": 5.2661745472352287e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=383 num_sets=5476"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20957760,
+      "real_time": 5.1933264522311646e+01,
+      "cpu_time": 5.1930693976864056e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=6143 num_sets=342"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21623360,
+      "real_time": 5.5272121077176763e+01,
+      "cpu_time": 5.5271794392774993e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=98303 num_sets=22"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14NodeSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 22019872,
+      "real_time": 5.5613145917901640e+01,
+      "cpu_time": 5.5613271457647201e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1572863 num_sets=2"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 25565296,
+      "real_time": 1.2795930397186204e+01,
+      "cpu_time": 1.2796661302068337e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.000 size=21 num_sets=1597831"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33449920,
+      "real_time": 1.6287385010680296e+01,
+      "cpu_time": 1.6287489596404367e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=321 num_sets=104531"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33551360,
+      "real_time": 1.6865103484091460e+01,
+      "cpu_time": 1.6864730103371453e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=5121 num_sets=6553"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33587200,
+      "real_time": 1.4489412977837208e+01,
+      "cpu_time": 1.4488657970885940e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=81921 num_sets=410"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 34078720,
+      "real_time": 8.0510080106950443e+00,
+      "cpu_time": 8.0510602804754274e+00,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1310721 num_sets=26"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 28256368,
+      "real_time": 1.1638330341600938e+01,
+      "cpu_time": 1.1638158909876122e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=19 num_sets=1766023"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 31976848,
+      "real_time": 1.6168073008994615e+01,
+      "cpu_time": 1.6167986850991817e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=319 num_sets=105187"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33456720,
+      "real_time": 1.6039931741558512e+01,
+      "cpu_time": 1.6039680219654716e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=5119 num_sets=6555"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33580640,
+      "real_time": 1.4798944193715283e+01,
+      "cpu_time": 1.4798237883461855e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=81919 num_sets=410"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 34078304,
+      "real_time": 8.1884206786305960e+00,
+      "cpu_time": 8.1884690916708394e+00,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1310719 num_sets=26"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 20771920,
+      "real_time": 2.5725247977497986e+01,
+      "cpu_time": 2.5724608365485995e+01,
+      "time_unit": "ns",
+      "label": "lf=0.53 cmp=0.000 size=21 num_sets=99865"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20908800,
+      "real_time": 2.6444213212284431e+01,
+      "cpu_time": 2.6444054895620230e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=321 num_sets=6534"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20992000,
+      "real_time": 2.4460505966733141e+01,
+      "cpu_time": 2.4460434165436524e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=5121 num_sets=410"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 21299200,
+      "real_time": 2.8968900621223909e+01,
+      "cpu_time": 2.8969094613909071e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=81921 num_sets=26"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 3.2070420274976641e+01,
+      "cpu_time": 3.2070220279747929e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=0.000 size=1310721 num_sets=2"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 21192384,
+      "real_time": 2.2823822724009563e+01,
+      "cpu_time": 2.2822918082261612e+01,
+      "time_unit": "ns",
+      "label": "lf=0.95 cmp=0.000 size=19 num_sets=110377"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 21986800,
+      "real_time": 2.6128591240132263e+01,
+      "cpu_time": 2.6128784725380221e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=319 num_sets=6575"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 20926400,
+      "real_time": 2.5049001217726968e+01,
+      "cpu_time": 2.5048054228186466e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=5119 num_sets=410"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 21295040,
+      "real_time": 2.9178695793214338e+01,
+      "cpu_time": 2.9177571772541434e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=81919 num_sets=26"
+    },
+    {
+      "name": "BM<Iterate_Cold, folly::F14VectorSet, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 20971264,
+      "real_time": 2.4654121627480951e+01,
+      "cpu_time": 2.4654321837657260e+01,
+      "time_unit": "ns",
+      "label": "lf=1.00 cmp=0.000 size=1310719 num_sets=2"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 4, Density::kMin>/16/iterations:20000000",
+      "iterations": 31580656,
+      "real_time": 3.3382414786303102e+01,
+      "cpu_time": 3.3381680006915389e+01,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=3.572 size=17 num_sets=1973791"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 4, Density::kMin>/256/iterations:20000000",
+      "iterations": 33423872,
+      "real_time": 8.3466017646252382e+01,
+      "cpu_time": 8.3462953813371755e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=3.970 size=257 num_sets=130562"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 4, Density::kMin>/4096/iterations:20000000",
+      "iterations": 33550336,
+      "real_time": 7.8745329080138390e+01,
+      "cpu_time": 7.8744395316945329e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=3.998 size=4097 num_sets=8191"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 4, Density::kMin>/65536/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 7.3076527939974767e+01,
+      "cpu_time": 7.3076365083430105e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=4.000 size=65537 num_sets=512"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 4, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 33554432,
+      "real_time": 6.1088130109965277e+01,
+      "cpu_time": 6.1088140547308541e+01,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=4.000 size=1048577 num_sets=32"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 4, Density::kMax>/16/iterations:20000000",
+      "iterations": 34636864,
+      "real_time": 2.7835844944164919e+01,
+      "cpu_time": 2.7834640226118964e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=2.024 size=31 num_sets=1082402"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 4, Density::kMax>/256/iterations:20000000",
+      "iterations": 32569840,
+      "real_time": 3.3405337466485662e+01,
+      "cpu_time": 3.3405091857980167e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.001 size=511 num_sets=65665"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 4, Density::kMax>/4096/iterations:20000000",
+      "iterations": 33497072,
+      "real_time": 3.6139771687245982e+01,
+      "cpu_time": 3.6139206614789323e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.000 size=8191 num_sets=4097"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 4, Density::kMax>/65536/iterations:20000000",
+      "iterations": 33681392,
+      "real_time": 3.2381497069117188e+01,
+      "cpu_time": 3.2381592928219227e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.000 size=131071 num_sets=257"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 4, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 35651312,
+      "real_time": 1.7340558281963176e+01,
+      "cpu_time": 1.7339788869495766e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.000 size=2097151 num_sets=17"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 64, Density::kMin>/16/iterations:20000000",
+      "iterations": 21711712,
+      "real_time": 1.4043819144065995e+02,
+      "cpu_time": 1.4043409791910244e+02,
+      "time_unit": "ns",
+      "label": "lf=0.27 cmp=3.572 size=17 num_sets=123362"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 64, Density::kMin>/256/iterations:20000000",
+      "iterations": 20892160,
+      "real_time": 1.4200474760605707e+02,
+      "cpu_time": 1.4199778021997500e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=3.970 size=257 num_sets=8161"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 64, Density::kMin>/4096/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 1.4832868373559904e+02,
+      "cpu_time": 1.4832605404850597e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=3.998 size=4097 num_sets=512"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 64, Density::kMin>/65536/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 1.4429534758164664e+02,
+      "cpu_time": 1.4428781862259319e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=4.000 size=65537 num_sets=32"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 64, Density::kMin>/1048576/iterations:20000000",
+      "iterations": 20971520,
+      "real_time": 1.2839493592764484e+02,
+      "cpu_time": 1.2839086084362461e+02,
+      "time_unit": "ns",
+      "label": "lf=0.25 cmp=4.000 size=1048577 num_sets=2"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 64, Density::kMax>/16/iterations:20000000",
+      "iterations": 20565904,
+      "real_time": 6.8377089018774484e+01,
+      "cpu_time": 6.8369115746115142e+01,
+      "time_unit": "ns",
+      "label": "lf=0.48 cmp=2.026 size=31 num_sets=67651"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 64, Density::kMax>/256/iterations:20000000",
+      "iterations": 20360800,
+      "real_time": 7.0012202174259514e+01,
+      "cpu_time": 7.0010845055200249e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.001 size=511 num_sets=4105"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 64, Density::kMax>/4096/iterations:20000000",
+      "iterations": 21012320,
+      "real_time": 6.8926292542071380e+01,
+      "cpu_time": 6.8923906403491003e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.000 size=8191 num_sets=257"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 64, Density::kMax>/65536/iterations:20000000",
+      "iterations": 20051568,
+      "real_time": 6.8668360614348416e+01,
+      "cpu_time": 6.8668066008643208e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.000 size=131071 num_sets=17"
+    },
+    {
+      "name": "BM<Iterate_Cold, google::dense_hash_set, 64, Density::kMax>/1048576/iterations:20000000",
+      "iterations": 20971360,
+      "real_time": 8.5492131038312763e+01,
+      "cpu_time": 8.5490306637224577e+01,
+      "time_unit": "ns",
+      "label": "lf=0.50 cmp=2.000 size=2097151 num_sets=2"
+    }
+  ]
+}


### PR DESCRIPTION
The InsertHit_Cold benchmark with 64 byte values had an interesting bad codegen for F14 that triggered a store-to-load forwarding failure. A workaround to this has been committed to folly. This diff includes a benchmark run that includes the fix