### PR TITLE
fix folly / F14 build files

### DIFF
--- a/BUILD.folly
+++ b/BUILD.folly
@@ -3,9 +3,11 @@ cc_library(
     includes = [""],
     srcs = [
         "folly/FileUtil.cpp",
+        "folly/ScopeGuard.cpp",
         "folly/container/detail/F14Table.cpp",
         "folly/lang/Assume.cpp",
         "folly/lang/SafeAssert.cpp",
+        "folly/net/NetOps.cpp",
     ],
     hdrs = glob([
         "folly/**/*.h",
@@ -13,6 +15,8 @@ cc_library(
     defines = [
         "FOLLY_NO_CONFIG",
         "FOLLY_HAVE_MEMRCHR",
+	"FOLLY_HAVE_SENDMMSG",
+	"FOLLY_HAVE_RECVMMSG",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Benchmarks for comparing hashtable implementations.
 1. Build:
 
 ```shell
-bazel build :hashtable_benchmarks
+bazel build --cxxopt='-std=c++14' :hashtable_benchmarks
 ```
 
 Note that `-c opt` is the default.


### PR DESCRIPTION
Summary:
* folly has been a C++14 library for a while now
  (https://github.com/facebook/folly/commit/7bdb20f850299dc14045ef9e00b8b90a1dce17b7),
  previously we did not pull in anything that required C++14 language
  features. This diff adds the C++14 option to the bazel build command
  explicitly.
* This diff also adds a few newly-added cpp files required in the dependency.