### PR TITLE
Make the project buildable again

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -43,7 +43,7 @@ cc_binary(
         "@google_sparsehash//:sparsehash",
         "@skarupke//:skarupke",
     ],
-    stamp = True,
+    stamp = 1,
 )
 
 cc_binary(

--- a/BUILD.folly
+++ b/BUILD.folly
@@ -5,7 +5,7 @@ cc_library(
         "folly/FileUtil.cpp",
         "folly/ScopeGuard.cpp",
         "folly/container/detail/F14Table.cpp",
-        "folly/lang/Assume.cpp",
+        "folly/lang/Assume.h",
         "folly/lang/ToAscii.cpp",
         "folly/lang/SafeAssert.cpp",
         "folly/net/NetOps.cpp",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -59,8 +59,8 @@ http_archive(
 http_archive(
     name = "facebook_folly",
     build_file = "//:BUILD.folly",
-    strip_prefix = "folly-master",
-    urls = ["https://github.com/facebook/folly/archive/master.zip"],
+    strip_prefix = "folly-main",
+    urls = ["https://github.com/facebook/folly/archive/main.zip"],
 )
 
 # ska::flat_hash_set and ska::bytell_hash_set


### PR DESCRIPTION
On newer bazel versions (e.g. 6.4.0), stamp attribute of cc_binary can only be -1, 0 or 1. `True` is no longer accepted.

Also updated folly related BUILD files to reflect their changes.